### PR TITLE
DM-16700: Update for latest version of fgcm, including log PWV and filter offsets.

### DIFF
--- a/cookbook/fgcmMakeLutHscFromTable.py
+++ b/cookbook/fgcmMakeLutHscFromTable.py
@@ -8,5 +8,5 @@ config.filterNames = ('g', 'r', 'i', 'z', 'y')
 # Here, both i and i2 map onto i2 which will be the standard
 config.stdFilterNames = ('g', 'r', 'i', 'z', 'y')
 # Pre-generated atmosphere table distributed with FGCM
-config.atmosphereTableName = 'fgcm_atm_subaru1'
+config.atmosphereTableName = 'fgcm_atm_subaru2'
 

--- a/python/lsst/fgcmcal/fgcmMakeLut.py
+++ b/python/lsst/fgcmcal/fgcmMakeLut.py
@@ -679,8 +679,9 @@ class FgcmMakeLutTask(pipeBase.CmdLineTask):
         rec['luttype'] = 'I1'
         rec['lut'][:] = self.fgcmLutMaker.lut['I1'].flatten()
 
-        derivTypes = ['D_PMB', 'D_PWV', 'D_O3', 'D_LNTAU', 'D_ALPHA', 'D_SECZENITH',
-                      'D_PMB_I1', 'D_PWV_I1', 'D_O3_I1', 'D_LNTAU_I1', 'D_ALPHA_I1', 'D_SECZENITH_I1']
+        derivTypes = ['D_PMB', 'D_LNPWV', 'D_O3', 'D_LNTAU', 'D_ALPHA', 'D_SECZENITH',
+                      'D_PMB_I1', 'D_LNPWV_I1', 'D_O3_I1', 'D_LNTAU_I1', 'D_ALPHA_I1',
+                      'D_SECZENITH_I1']
         for derivType in derivTypes:
             rec = lutCat.addNew()
             rec['luttype'] = derivType

--- a/tests/fgcmcalTestBase.py
+++ b/tests/fgcmcalTestBase.py
@@ -115,14 +115,14 @@ class FgcmcalTestBase(object):
         self.assertFloatsAlmostEqual(i10Std, lutStd[0]['I10STD'], msg='I10Std', rtol=1e-5)
 
         indices = fgcmLut.getIndices(np.arange(nBand, dtype=np.int32),
-                                     np.zeros(nBand) + lutStd[0]['PWVSTD'],
+                                     np.zeros(nBand) + np.log(lutStd[0]['PWVSTD']),
                                      np.zeros(nBand) + lutStd[0]['O3STD'],
                                      np.zeros(nBand) + np.log(lutStd[0]['TAUSTD']),
                                      np.zeros(nBand) + lutStd[0]['ALPHASTD'],
                                      np.zeros(nBand) + 1. / np.cos(np.radians(lutStd[0]['ZENITHSTD'])),
                                      np.zeros(nBand, dtype=np.int32),
                                      np.zeros(nBand) + lutStd[0]['PMBSTD'])
-        i0 = fgcmLut.computeI0(np.zeros(nBand) + lutStd[0]['PWVSTD'],
+        i0 = fgcmLut.computeI0(np.zeros(nBand) + np.log(lutStd[0]['PWVSTD']),
                                np.zeros(nBand) + lutStd[0]['O3STD'],
                                np.zeros(nBand) + np.log(lutStd[0]['TAUSTD']),
                                np.zeros(nBand) + lutStd[0]['ALPHASTD'],
@@ -132,7 +132,7 @@ class FgcmcalTestBase(object):
 
         self.assertFloatsAlmostEqual(i0Recon, i0, msg='i0Recon', rtol=1e-5)
 
-        i1 = fgcmLut.computeI1(np.zeros(nBand) + lutStd[0]['PWVSTD'],
+        i1 = fgcmLut.computeI1(np.zeros(nBand) + np.log(lutStd[0]['PWVSTD']),
                                np.zeros(nBand) + lutStd[0]['O3STD'],
                                np.zeros(nBand) + np.log(lutStd[0]['TAUSTD']),
                                np.zeros(nBand) + lutStd[0]['ALPHASTD'],
@@ -220,7 +220,7 @@ class FgcmcalTestBase(object):
 
         butler = dafPersistence.butler.Butler(self.testDir)
 
-        zps = butler.get('fgcmZeropoints', fgcmcycle=0)
+        zps = butler.get('fgcmZeropoints', fgcmcycle=self.config.cycleNumber)
 
         # Check the numbers of zeropoints in all, good, okay, and bad
         self.assertEqual(nZp, len(zps))
@@ -238,7 +238,7 @@ class FgcmcalTestBase(object):
         test, = np.where(zps['fgcmZpt'][gd] < -9000.0)
         self.assertEqual(0, len(test))
 
-        stds = butler.get('fgcmStandardStars', fgcmcycle=0)
+        stds = butler.get('fgcmStandardStars', fgcmcycle=self.config.cycleNumber)
 
         self.assertEqual(nStdStars, len(stds))
 
@@ -310,7 +310,7 @@ class FgcmcalTestBase(object):
 
         # Test the joincal_photoCalib output
 
-        zptCat = butler.get('fgcmZeropoints', fgcmcycle=0)
+        zptCat = butler.get('fgcmZeropoints', fgcmcycle=self.config.cycleNumber)
         selected = (zptCat['fgcmFlag'] < 16)
 
         # Read in all the calibrations, these should all be there

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -74,14 +74,14 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.config = fgcmcal.FgcmMakeLutConfig()
         self.config.filterNames = ['r', 'i']
         self.config.stdFilterNames = ['r', 'i']
-        self.config.atmosphereTableName = 'fgcm_atm_subaru1_test'
+        self.config.atmosphereTableName = 'fgcm_atm_subaru2_test'
         self.otherArgs = []
 
         nBand = 2
         i0Std = np.array([0.07877351, 0.06464688])
         i10Std = np.array([-0.00061516, -0.00063434])
-        i0Recon = np.array([0.06897538, 0.05616964])
-        i10Recon = np.array([-6.97094875, 3.69335364])
+        i0Recon = np.array([0.0689530429, 0.05600673])
+        i10Recon = np.array([-7.01847144, 3.62675740])
 
         self._testFgcmMakeLut(nBand, i0Std, i0Recon, i10Std, i10Recon)
 
@@ -132,6 +132,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.config.superStarSubCcd = True
         self.config.superStarSubCcdChebyshevOrder = 1
         self.config.modelMagErrors = False
+        self.config.sigmaCalRange = (0.003, 0.003)
         self.otherArgs = []
 
         nZp = 1232
@@ -139,13 +140,26 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         nOkZp = 33
         nBadZp = 1199
         nStdStars = 472
-        nPlots = 27
+        nPlots = 30
+
+        self._testFgcmFitCycle(nZp, nGoodZp, nOkZp, nBadZp, nStdStars, nPlots)
+
+        # Test the second fit cycle -- need to copy to unfreeze config
+        newConfig = fgcmcal.FgcmFitCycleConfig()
+        newConfig.update(**self.config.toDict())
+        newConfig.cycleNumber = 1
+        self.config = newConfig
+
+        # These numbers change slightly after the additional cuts
+        nGoodZp = 26
+        nOkZp = 32
+        nBadZp = 1200
 
         self._testFgcmFitCycle(nZp, nGoodZp, nOkZp, nBadZp, nStdStars, nPlots)
 
         # And output the products
         self.config = fgcmcal.FgcmOutputProductsConfig()
-        self.config.cycleNumber = 0
+        self.config.cycleNumber = 1
         self.config.photoCal.photoCatName = 'sdss-dr9-fink-v5b'
         self.config.photoCal.colorterms.data = {}
         self.config.photoCal.colorterms.data['sdss*'] = lsst.pipe.tasks.colorterms.ColortermDict()
@@ -171,7 +185,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.config.refObjLoader.retarget(target=LoadAstrometryNetObjectsTask)
 
         filterMapping = {'r': 'HSC-R', 'i': 'HSC-I'}
-        zpOffsets = np.array([8.877202988, 9.163103988])
+        zpOffsets = np.array([8.877352, 9.166878])
 
         self._testFgcmOutputProducts(visitDataRefName, ccdDataRefName,
                                      filterMapping, zpOffsets,


### PR DESCRIPTION
Add support for latest fgcm, including fitting in ln(PWV) space, quadratic
temporal variation of ln(PWV), offsets between cross-calibrated filters (e.g.,
HSC r/r2 and i/i2), and estimation of the systematic error floor in the
calibration. Another fit cycle was added to the tests, as this excercises
key bits of the code where fit parameters are re-ingested.