### PR TITLE
DM-16871: Change flux to be calibrated from 'flux' to 'instFlux'.

### DIFF
--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -185,7 +185,10 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.config.refObjLoader.retarget(target=LoadAstrometryNetObjectsTask)
 
         filterMapping = {'r': 'HSC-R', 'i': 'HSC-I'}
-        zpOffsets = np.array([8.877352, 9.166878])
+        # These zeropoint offsets are empirical, and are there
+        # to check if changes in the code are altering the final
+        # output in a measurable way.
+        zpOffsets = np.array([-0.0227140467, 0.266808])
 
         self._testFgcmOutputProducts(visitDataRefName, ccdDataRefName,
                                      filterMapping, zpOffsets,


### PR DESCRIPTION
The PhotoCal task expects instFlux inputs, and we now explicitly pass instFlux
values rather than Jansky fluxes.  This fix means that the computed zeropoint
offsets are appropriately approximately 0 rather than approximately 9.