### PR TITLE
DM-16490: Update computeCcdOffsets() to use makeSkyWcs

### DIFF
--- a/cookbook/fgcmFitCycleHscCookbook_cycle00_config.py
+++ b/cookbook/fgcmFitCycleHscCookbook_cycle00_config.py
@@ -29,8 +29,6 @@ config.washMjds = (56700.0, 57500.0, 57700.0, 58050.0)
 config.epochMjds = (56700., 57420., 57606.)
 # Latitude of the observatory
 config.latitude = 19.8256
-# Pixel scale (arcseconds)
-config.pixelScale = 0.17
 # Amount of gray extinction to be considered "photometric".  This will
 # get ratcheded down in further cycles.
 config.expGrayPhotometricCut = (-0.05, -0.05, -0.05, -0.05, -0.05)

--- a/python/lsst/fgcmcal/fgcmBuildStars.py
+++ b/python/lsst/fgcmcal/fgcmBuildStars.py
@@ -431,6 +431,7 @@ class FgcmBuildStarsTask(pipeBase.CmdLineTask):
             rec['telra'] = radec.getRa().asDegrees()
             rec['teldec'] = radec.getDec().asDegrees()
             rec['telha'] = visitInfo.getBoresightHourAngle().asDegrees()
+            rec['telrot'] = visitInfo.getBoresightRotAngle().asDegrees()
             rec['mjd'] = visitInfo.getDate().get(system=DateTime.MJD)
             rec['exptime'] = visitInfo.getExposureTime()
             # convert from Pa to millibar
@@ -849,6 +850,7 @@ class FgcmBuildStarsTask(pipeBase.CmdLineTask):
         schema.addField('telra', type=np.float64, doc="Pointing RA (deg)")
         schema.addField('teldec', type=np.float64, doc="Pointing Dec (deg)")
         schema.addField('telha', type=np.float64, doc="Pointing Hour Angle (deg)")
+        schema.addField('telrot', type=np.float64, doc="Camera rotation (deg)")
         schema.addField('mjd', type=np.float64, doc="MJD of visit")
         schema.addField('exptime', type=np.float32, doc="Exposure time")
         schema.addField('pmb', type=np.float32, doc="Pressure (millibar)")

--- a/python/lsst/fgcmcal/fgcmCalibrateTract.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTract.py
@@ -260,7 +260,10 @@ class FgcmCalibrateTractTask(pipeBase.CmdLineTask):
                                     True, False, tract=tract)
         # Turn off plotting in tract mode
         configDict['doPlots'] = False
-        ccdOffsets = computeCcdOffsets(camera, self.config.fgcmFitCycle.pixelScale)
+
+        # Use the first orientation.
+        # TODO: DM-21215 will generalize to arbitrary camera orientations
+        ccdOffsets = computeCcdOffsets(camera, fgcmExpInfo['TELROT'][0])
         del camera
 
         # Set up the fit cycle task

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -214,11 +214,12 @@ class FgcmFitCycleConfig(pexConfig.Config):
         dtype=float,
         default=None,
     )
-    # TODO: DM-16490 will make this unneccessary
+    # pixelScale is deprecated by DM-16490.
     pixelScale = pexConfig.Field(
         doc="Pixel scale (arcsec/pixel) (temporary)",
         dtype=float,
-        default=None,
+        deprecated="This field is no longer used.  It will be removed after v19.",
+        optional=True,
     )
     brightObsGrayMax = pexConfig.Field(
         doc="Maximum gray extinction to be considered bright observation",
@@ -612,7 +613,9 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
         fgcmExpInfo = translateVisitCatalog(visitCat)
         del visitCat
 
-        ccdOffsets = computeCcdOffsets(camera, self.config.pixelScale)
+        # Use the first orientation.
+        # TODO: DM-21215 will generalize to arbitrary camera orientations
+        ccdOffsets = computeCcdOffsets(camera, fgcmExpInfo['TELROT'][0])
 
         noFitsDict = {'lutIndex': lutIndexVals,
                       'lutStd': lutStd,

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -214,11 +214,11 @@ class FgcmFitCycleConfig(pexConfig.Config):
         dtype=float,
         default=None,
     )
-    # pixelScale is deprecated by DM-16490.
     pixelScale = pexConfig.Field(
         doc="Pixel scale (arcsec/pixel) (temporary)",
         dtype=float,
-        deprecated="This field is no longer used.  It will be removed after v19.",
+        deprecated=("This field is no longer used, and has been deprecated by DM-16490. "
+                    "It will be removed after v19."),
         optional=True,
     )
     brightObsGrayMax = pexConfig.Field(

--- a/tests/test_ccdoffsets.py
+++ b/tests/test_ccdoffsets.py
@@ -21,7 +21,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Test the fgcmcal computeCcdOffsets code with testdata_jointcal.
-
 """
 
 import unittest
@@ -63,6 +62,8 @@ class FgcmCcdOffsetsTest(lsst.utils.tests.TestCase):
         # Spot check relative orientations of some of the ccds
         # This is based on
         # https://subarutelescope.org/Observing/Instruments/HSC/CCDPosition_20170212.png
+        # The goal here is to check that North is Up, South is Down,
+        # East is Left, and West is Right.
         self.assertLess(ccdOffsets['DELTA_RA'][15], ccdOffsets['DELTA_RA'][10])
         self.assertLess(ccdOffsets['DELTA_RA'][95], ccdOffsets['DELTA_RA'][90])
         self.assertGreater(ccdOffsets['DELTA_RA'][46], 0.0)
@@ -72,6 +73,14 @@ class FgcmCcdOffsetsTest(lsst.utils.tests.TestCase):
         self.assertGreater(ccdOffsets['DELTA_DEC'][97], 0.0)
 
         # Check the sizes
+        # The projected size of the ccds varies with radius over the large
+        # HSC field-of-view. Empirically, the x size is between 0.07 and 0.10 deg
+        # and the y size is between 0.17 and 0.20 deg for the non-rotated CCDs.
+        # This test checks that the orientations of the CCDs are as expected for
+        # rotated/non-rotated CCDs (relative size of RA/DEC), and that the size
+        # is roughly correct.  Because these values are only used for visualization
+        # in the fgcm code, this does not need to be perfect.
+
         rotatedCcds = [100, 101, 102, 103]
 
         for i, ccd in enumerate(ccdOffsets['CCDNUM']):

--- a/tests/test_ccdoffsets.py
+++ b/tests/test_ccdoffsets.py
@@ -1,0 +1,102 @@
+# See COPYRIGHT file at the top of the source tree.
+#
+# This file is part of fgcmcal.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Test the fgcmcal computeCcdOffsets code with testdata_jointcal.
+
+"""
+
+import unittest
+import os
+
+import lsst.utils
+import lsst.daf.persistence as dafPersist
+
+import lsst.fgcmcal as fgcmcal
+
+
+class FgcmCcdOffsetsTest(lsst.utils.tests.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls.dataDir = lsst.utils.getPackageDir('testdata_jointcal')
+        except lsst.pex.exceptions.NotFoundError:
+            raise unittest.SkipTest("testdata_jointcal not setup")
+
+    def test_fgcmCcdOffsetsHsc(self):
+        """
+        Test computation of ccd offsets for HSC.
+        """
+
+        lsst.log.setLevel("HscMapper", lsst.log.FATAL)
+
+        butler = dafPersist.Butler(os.path.join(self.dataDir, 'hsc'))
+
+        visit = 903986
+        ccd = 16
+
+        visitInfo = butler.get('calexp_visitInfo', visit=visit, ccd=ccd)
+        rotAngle = visitInfo.getBoresightRotAngle().asDegrees()
+
+        camera = butler.get('camera')
+
+        ccdOffsets = fgcmcal.utilities.computeCcdOffsets(camera, rotAngle)
+
+        # Spot check relative orientations of some of the ccds
+        # This is based on
+        # https://subarutelescope.org/Observing/Instruments/HSC/CCDPosition_20170212.png
+        self.assertLess(ccdOffsets['DELTA_RA'][15], ccdOffsets['DELTA_RA'][10])
+        self.assertLess(ccdOffsets['DELTA_RA'][95], ccdOffsets['DELTA_RA'][90])
+        self.assertGreater(ccdOffsets['DELTA_RA'][46], 0.0)
+
+        self.assertLess(ccdOffsets['DELTA_DEC'][15], ccdOffsets['DELTA_DEC'][95])
+        self.assertLess(ccdOffsets['DELTA_DEC'][10], ccdOffsets['DELTA_DEC'][90])
+        self.assertGreater(ccdOffsets['DELTA_DEC'][97], 0.0)
+
+        # Check the sizes
+        rotatedCcds = [100, 101, 102, 103]
+
+        for i, ccd in enumerate(ccdOffsets['CCDNUM']):
+            if ccd in rotatedCcds:
+                self.assertLess(ccdOffsets['RA_SIZE'][i], ccdOffsets['DEC_SIZE'][i])
+                self.assertGreater(ccdOffsets['DEC_SIZE'][i], 0.17)
+                self.assertLess(ccdOffsets['DEC_SIZE'][i], 0.20)
+                self.assertGreater(ccdOffsets['RA_SIZE'][i], 0.07)
+                self.assertLess(ccdOffsets['RA_SIZE'][i], 0.10)
+            else:
+                self.assertGreater(ccdOffsets['RA_SIZE'][i], ccdOffsets['DEC_SIZE'][i])
+                self.assertGreater(ccdOffsets['RA_SIZE'][i], 0.17)
+                self.assertLess(ccdOffsets['RA_SIZE'][i], 0.20)
+                self.assertGreater(ccdOffsets['DEC_SIZE'][i], 0.07)
+                self.assertLess(ccdOffsets['DEC_SIZE'][i], 0.10)
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -267,7 +267,6 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         config.washMjds = (0.0, )
         config.epochMjds = (0.0, 100000.0)
         config.latitude = 19.8256
-        config.pixelScale = 0.17
         config.expGrayPhotometricCut = (-0.05, -0.05)
         config.expGrayHighCut = (0.2, 0.2)
         config.aperCorrFitNBins = 0


### PR DESCRIPTION
This update deprecates the pixelScale configuration parameter which is no
longer necessary now that all the camera units are correct and makeSkyWcs works
properly for HSC.  However, due to a bug in the data files in
testdata_jointcal, there is still an HSC-specific hack that can be fixed after
DM-17597 is complete.