### PR TITLE
DM-21501: Implement internal aperture corrections for fgcmcal tract mode

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -27,8 +27,8 @@ The environment should be set up as follows:
 ```
 setup lsst_distrib
 
-export RCRERUN=RC/w_2019_18/DM-19151-sfm
-export COOKBOOKRERUN=fgcm_cookbook_w_2019_18
+export RCRERUN=RC/w_2019_38/DM-21386-sfm
+export COOKBOOKRERUN=fgcm_cookbook_w_2019_38
 ```
 
 The `RCRERUN` env variable should be set to the most recent completed rerun

--- a/cookbook/fgcmFitCycleHscCookbook_cycle00_config.py
+++ b/cookbook/fgcmFitCycleHscCookbook_cycle00_config.py
@@ -37,8 +37,12 @@ config.expGrayPhotometricCut = (-0.05, -0.05, -0.05, -0.05, -0.05)
 config.expGrayHighCut = (0.2, 0.2, 0.2, 0.2, 0.2)
 # Number of bins to do aperture correction.  Not currently supported in LSST stack.
 config.aperCorrFitNBins = 0
-# "Fudge factors" for computing SED slope (best values for HSC not determined yet)
-config.sedFudgeFactors = (1.0, 1.0, 1.0, 1.0, 1.0)
+# Aperture correction input slope parameters.  There should be one slope ber band.
+# This is used when there is insufficient data to fit the parameters from the data
+# itself (e.g. tract mode or RC2).
+config.aperCorrInputParameters = (-1.0150, -0.9694, -1.7229, -1.4549, -1.1998)
+# "Fudge factors" for computing SED slope
+config.sedFudgeFactors = (0.25, 1.0, 1.0, 0.25, 0.25)
 # Color cuts for stars to use for calibration.  Each element is a string with
 # band1, band2, range_low, range_high such that range_low < (band1 - band2) < range_high
 config.starColorCuts = ('g,r,-0.25,2.25',

--- a/cookbook/fgcmFitCycleHscCookbook_cycle00_config.py
+++ b/cookbook/fgcmFitCycleHscCookbook_cycle00_config.py
@@ -42,6 +42,8 @@ config.aperCorrFitNBins = 0
 # itself (e.g. tract mode or RC2).
 config.aperCorrInputParameters = (-1.0150, -0.9694, -1.7229, -1.4549, -1.1998)
 # "Fudge factors" for computing SED slope
+# These are approximating by looking at stellar SED templates, and are the same
+# as used in DES calibrations (-E. Rykoff)
 config.sedFudgeFactors = (0.25, 1.0, 1.0, 0.25, 0.25)
 # Color cuts for stars to use for calibration.  Each element is a string with
 # band1, band2, range_low, range_high such that range_low < (band1 - band2) < range_high

--- a/python/lsst/fgcmcal/fgcmBuildStars.py
+++ b/python/lsst/fgcmcal/fgcmBuildStars.py
@@ -509,6 +509,8 @@ class FgcmBuildStarsTask(pipeBase.CmdLineTask):
                 # only says that a given raw is available, and the src may not
                 # be accessible or processed in a specific repo.
                 dataRefs = butler.subset('src')
+        elif self.config.checkAllCcds:
+            scanAllCcds = True
 
         groupedDataRefs = {}
         for dataRef in dataRefs:
@@ -522,10 +524,18 @@ class FgcmBuildStarsTask(pipeBase.CmdLineTask):
                 for ccdId in ccdIds:
                     dataId[self.config.ccdDataRefName] = ccdId
                     if butler.datasetExists('src', dataId=dataId):
-                        groupedDataRefs[visit].append(butler.dataRef('src', dataId=dataId))
+                        goodDataRef = butler.dataRef('src', dataId=dataId)
+                        if visit in groupedDataRefs:
+                            if (goodDataRef.dataId[self.config.ccdDataRefName] not in
+                               [d.dataId[self.config.ccdDataRefName] for d in groupedDataRefs[visit]]):
+                                groupedDataRefs[visit].append(goodDataRef)
+                        else:
+                            groupedDataRefs[visit] = [goodDataRef]
             else:
                 if visit in groupedDataRefs:
-                    groupedDataRefs[visit].append(dataRef)
+                    if (dataRef.dataId[self.config.ccdDataRefName] not in
+                       [d.dataId[self.config.ccdDataRefName] for d in groupedDataRefs[visit]]):
+                        groupedDataRefs[visit].append(dataRef)
                 else:
                     groupedDataRefs[visit] = [dataRef]
 

--- a/python/lsst/fgcmcal/fgcmCalibrateTract.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTract.py
@@ -435,11 +435,11 @@ class FgcmCalibrateTractTask(pipeBase.CmdLineTask):
         stdStruct = fgcmFitCycle.fgcmStars.retrieveStdStarCatalog(fgcmFitCycle.fgcmPars)
         stdCat = makeStdCat(stdSchema, stdStruct)
 
-        outStruct = self.fgcmOutputProducts.generateOutputProducts(butler, tract,
-                                                                   visitCat,
-                                                                   zptCat, atmCat, stdCat,
-                                                                   self.config.fgcmBuildStars,
-                                                                   self.config.fgcmFitCycle)
+        outStruct = self.fgcmOutputProducts.generateTractOutputProducts(butler, tract,
+                                                                        visitCat,
+                                                                        zptCat, atmCat, stdCat,
+                                                                        self.config.fgcmBuildStars,
+                                                                        self.config.fgcmFitCycle)
         outStruct.repeatability = fgcmFitCycle.fgcmPars.compReservedRawRepeatability
 
         return outStruct

--- a/python/lsst/fgcmcal/fgcmCalibrateTract.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTract.py
@@ -81,7 +81,7 @@ class FgcmCalibrateTractConfig(pexConfig.Config):
     def setDefaults(self):
         pexConfig.Config.setDefaults(self)
 
-        self.fgcmBuildStars.checkAllCcds = True
+        self.fgcmBuildStars.checkAllCcds = False
         self.fgcmFitCycle.useRepeatabilityForExpGrayCuts = True
         self.fgcmFitCycle.quietMode = True
         self.fgcmOutputProducts.doReferenceCalibration = False
@@ -226,6 +226,8 @@ class FgcmCalibrateTractTask(pipeBase.CmdLineTask):
 
         if not self.config.fgcmBuildStars.doReferenceMatches:
             raise RuntimeError("Must run FgcmCalibrateTract with fgcmBuildStars.doReferenceMatches")
+        if self.config.fgcmBuildStars.checkAllCcds:
+            raise RuntimeError("Cannot run FgcmCalibrateTract with fgcmBuildStars.checkAllCcds set to True")
 
         self.makeSubtask("fgcmBuildStars", butler=butler)
         self.makeSubtask("fgcmOutputProducts", butler=butler)

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -62,13 +62,15 @@ class FgcmFitCycleConfig(pexConfig.Config):
     fitFlag = pexConfig.ListField(
         doc=("Flag for which bands are directly constrained in the FGCM fit. "
              "Bands set to 0 will have the atmosphere constrained from observations "
-             "in other bands on the same night."),
+             "in other bands on the same night.  Must be same length as config.bands, "
+             "and matched band-by-band."),
         dtype=int,
         default=(0,),
     )
     requiredFlag = pexConfig.ListField(
         doc=("Flag for which bands are required for a star to be considered a calibration "
-             "star in the FGCM fit.  Typically this should be the same as fitFlag."),
+             "star in the FGCM fit.  Typically this should be the same as fitFlag.  Must "
+             "be same length as config.bands, and matched band-by-band."),
         dtype=int,
         default=(0,),
     )
@@ -263,13 +265,13 @@ class FgcmFitCycleConfig(pexConfig.Config):
     )
     expGrayPhotometricCut = pexConfig.ListField(
         doc=("Maximum (negative) exposure gray for a visit to be considered photometric. "
-             "There will be one value per band."),
+             "Must be same length as config.bands, and matched band-by-band."),
         dtype=float,
         default=(0.0,),
     )
     expGrayHighCut = pexConfig.ListField(
         doc=("Maximum (positive) exposure gray for a visit to be considered photometric. "
-             "There will be one value per band."),
+             "Must be same length as config.bands, and matched band-by-band."),
         dtype=float,
         default=(0.0,),
     )
@@ -293,19 +295,24 @@ class FgcmFitCycleConfig(pexConfig.Config):
         default=0.05,
     )
     aperCorrFitNBins = pexConfig.Field(
-        doc="Number of bins used in aperture correction fit.",
+        doc=("Number of aperture bins used in aperture correction fit.  When set to 0"
+             "no fit will be performed, and the config.aperCorrInputSlopes will be "
+             "used if available."),
         dtype=int,
         default=10,
     )
-    aperCorrInputParameters = pexConfig.ListField(
-        doc=("Aperture correction input slope parameters.  There should be one "
-             "slope per band.  This is used when there is insufficient data to "
-             "fit the parameters from the data itself (e.g. tract mode)."),
+    aperCorrInputSlopes = pexConfig.ListField(
+        doc=("Aperture correction input slope parameters.  These are used on the first "
+             "fit iteration, and aperture correction parameters will be updated from "
+             "the data if config.aperCorrFitNBins > 0.  It is recommended to set this"
+             "when there is insufficient data to fit the parameters (e.g. tract mode). "
+             "If set, must be same length as config.bands, and matched band-by-band."),
         dtype=float,
         default=[],
     )
     sedFudgeFactors = pexConfig.ListField(
-        doc="Fudge factors for computing linear SED from colors",
+        doc=("Fudge factors for computing linear SED from colors.  Must be same length as "
+             "config.bands, and matched band-by-band."),
         dtype=float,
         default=(0,),
     )
@@ -325,7 +332,9 @@ class FgcmFitCycleConfig(pexConfig.Config):
         default=0.10,
     )
     approxThroughput = pexConfig.ListField(
-        doc="Approximate overall throughput at start of calibration observations",
+        doc=("Approximate overall throughput at start of calibration observations. "
+             "May be 1 element (same for all bands) or the same length as config.bands, "
+             "and matched band-by-band."),
         dtype=float,
         default=(1.0, ),
     )

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -293,9 +293,16 @@ class FgcmFitCycleConfig(pexConfig.Config):
         default=0.05,
     )
     aperCorrFitNBins = pexConfig.Field(
-        doc="Aperture correction number of bins",
+        doc="Number of bins used in aperture correction fit.",
         dtype=int,
-        default=None,
+        default=10,
+    )
+    aperCorrInputParameters = pexConfig.ListField(
+        doc=("Aperture correction input slope parameters.  There should be one "
+             "slope per band.  This is used when there is insufficient data to "
+             "fit the parameters from the data itself (e.g. tract mode)."),
+        dtype=float,
+        default=[],
     )
     sedFudgeFactors = pexConfig.ListField(
         doc="Fudge factors for computing linear SED from colors",

--- a/python/lsst/fgcmcal/fgcmOutputProducts.py
+++ b/python/lsst/fgcmcal/fgcmOutputProducts.py
@@ -365,11 +365,11 @@ class FgcmOutputProductsTask(pipeBase.CmdLineTask):
         # We return the zp offsets
         return pipeBase.Struct(offsets=offsets)
 
-    def generateOutputProducts(self, butler, tract,
-                               visitCat, zptCat, atmCat, stdCat,
-                               fgcmBuildStarsConfig, fgcmFitCycleConfig):
+    def generateTractOutputProducts(self, butler, tract,
+                                    visitCat, zptCat, atmCat, stdCat,
+                                    fgcmBuildStarsConfig, fgcmFitCycleConfig):
         """
-        Generate the output products, as specified in the config.
+        Generate the output products for a given tract, as specified in the config.
 
         This method is here to have an alternate entry-point for
         FgcmCalibrateTract.

--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -154,6 +154,7 @@ def makeConfigDict(config, log, camera, maxIter,
                   'illegalValue': -9999.0,  # internally used by fgcm.
                   'starColorCuts': starColorCutList,
                   'aperCorrFitNBins': config.aperCorrFitNBins,
+                  'aperCorrInputParameters': np.array(config.aperCorrInputParameters),
                   'sedFudgeFactors': np.array(config.sedFudgeFactors),
                   'colorSplitIndices': np.array(config.colorSplitIndices),
                   'sigFgcmMaxErr': config.sigFgcmMaxErr,

--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -154,7 +154,7 @@ def makeConfigDict(config, log, camera, maxIter,
                   'illegalValue': -9999.0,  # internally used by fgcm.
                   'starColorCuts': starColorCutList,
                   'aperCorrFitNBins': config.aperCorrFitNBins,
-                  'aperCorrInputParameters': np.array(config.aperCorrInputParameters),
+                  'aperCorrInputSlopes': np.array(config.aperCorrInputSlopes),
                   'sedFudgeFactors': np.array(config.sedFudgeFactors),
                   'colorSplitIndices': np.array(config.colorSplitIndices),
                   'sigFgcmMaxErr': config.sigFgcmMaxErr,

--- a/tests/fgcmcalTestBase.py
+++ b/tests/fgcmcalTestBase.py
@@ -460,6 +460,12 @@ class FgcmcalTestBase(object):
             self.assertTrue(butler.datasetExists('transmission_atmosphere_fgcm_tract',
                                                  tract=tract, visit=visit))
 
+        # Check that we got the reference catalog output.
+        # This will raise an exception if the catalog is not there.
+        config = LoadIndexedReferenceObjectsConfig()
+        config.ref_dataset_name = 'fgcm_stars_%d' % (tract)
+        task = LoadIndexedReferenceObjectsTask(butler, config=config)  # noqa F841
+
     def _checkResult(self, result):
         """
         Check the result output from the task

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -105,7 +105,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         nGoodZp = 26
         nOkZp = 26
         nBadZp = 1206
-        nStdStars = 389
+        nStdStars = 390
         nPlots = 34
 
         self._testFgcmFitCycle(nZp, nGoodZp, nOkZp, nBadZp, nStdStars, nPlots, skipChecks=True)
@@ -142,7 +142,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.config.refObjLoader.ref_dataset_name = "sdss-dr9-fink-v5b"
 
         filterMapping = {'r': 'HSC-R', 'i': 'HSC-I'}
-        zpOffsets = np.array([-0.001419307198, -0.001693746657])
+        zpOffsets = np.array([-0.0013903317740, -0.0020539460238])
 
         self._testFgcmOutputProducts(visitDataRefName, ccdDataRefName,
                                      filterMapping, zpOffsets,
@@ -177,7 +177,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.fillDefaultFitCycleConfig(self.config.fgcmFitCycle)
         self.config.maxFitCycles = 2
 
-        rawRepeatability = np.array([0.006505881543, 0.008963255070])
+        rawRepeatability = np.array([0.007070288705, 0.0074971053995])
         filterNCalibMap = {'HSC-R': 13,
                            'HSC-I': 13}
 
@@ -272,6 +272,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         config.expGrayPhotometricCut = (-0.05, -0.05)
         config.expGrayHighCut = (0.2, 0.2)
         config.aperCorrFitNBins = 0
+        config.aperCorrInputParameters = (-0.9694, -1.7229)
         config.sedFudgeFactors = (1.0, 1.0)
         config.starColorCuts = ('r,i,-0.50,2.25',)
         config.freezeStdAtmosphere = True

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -177,6 +177,8 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.fillDefaultFitCycleConfig(self.config.fgcmFitCycle)
         self.config.maxFitCycles = 2
 
+        self.config.fgcmOutputProducts.doRefcatOutput = True
+
         rawRepeatability = np.array([0.007070288705, 0.0074971053995])
         filterNCalibMap = {'HSC-R': 13,
                            'HSC-I': 13}

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -172,6 +172,8 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
 
         self.config = fgcmcal.FgcmCalibrateTractConfig()
         self.fillDefaultBuildStarsConfig(self.config.fgcmBuildStars, visitDataRefName, ccdDataRefName)
+        self.config.fgcmBuildStars.checkAllCcds = False
+
         self.fillDefaultFitCycleConfig(self.config.fgcmFitCycle)
         self.config.maxFitCycles = 2
 

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -173,7 +173,6 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.config = fgcmcal.FgcmCalibrateTractConfig()
         self.fillDefaultBuildStarsConfig(self.config.fgcmBuildStars, visitDataRefName, ccdDataRefName)
         self.config.fgcmBuildStars.checkAllCcds = False
-
         self.fillDefaultFitCycleConfig(self.config.fgcmFitCycle)
         self.config.maxFitCycles = 2
 
@@ -274,7 +273,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         config.expGrayPhotometricCut = (-0.05, -0.05)
         config.expGrayHighCut = (0.2, 0.2)
         config.aperCorrFitNBins = 0
-        config.aperCorrInputParameters = (-0.9694, -1.7229)
+        config.aperCorrInputSlopes = (-0.9694, -1.7229)
         config.sedFudgeFactors = (1.0, 1.0)
         config.starColorCuts = ('r,i,-0.50,2.25',)
         config.freezeStdAtmosphere = True


### PR DESCRIPTION
Add the ability to use externally calibrated aperture corrections for use in tract mode when there isn't sufficient data to fit them empirically.  Also fix a dataRef logic error when running globally (e.g. PDR1) and the ability to output stars in tract mode, used for qa and debugging.