### PR TITLE
DM-21982: Update mag-flux conversions to explicitly use float64

### DIFF
--- a/python/lsst/fgcmcal/fgcmOutputProducts.py
+++ b/python/lsst/fgcmcal/fgcmOutputProducts.py
@@ -695,11 +695,11 @@ class FgcmOutputProductsTask(pipeBase.CmdLineTask):
         # Note that we don't have to set `resolved` because the default is False
 
         for b, band in enumerate(self.bands):
-            mag = fgcmStarCat['mag_std_noabs'][:, b] + offsets[b]
+            mag = fgcmStarCat['mag_std_noabs'][:, b].astype(np.float64) + offsets[b]
             # We want fluxes in nJy from calibrated AB magnitudes
             # (after applying offset).  Updated after RFC-549 and RFC-575.
             flux = (mag*units.ABmag).to_value(units.nJy)
-            fluxErr = (np.log(10.) / 2.5) * flux * fgcmStarCat['magErr_std'][:, b]
+            fluxErr = (np.log(10.) / 2.5) * flux * fgcmStarCat['magErr_std'][:, b].astype(np.float64)
 
             formattedCat['%s_flux' % (band)][:] = flux
             formattedCat['%s_fluxErr' % (band)][:] = fluxErr

--- a/tests/fgcmcalTestBase.py
+++ b/tests/fgcmcalTestBase.py
@@ -312,6 +312,14 @@ class FgcmcalTestBase(object):
         # And make sure the numbers are consistent
         test, = np.where(rawStars['id'][0] == refStruct.refCat['id'])
 
+        # Perform math on numpy arrays to maintain datatypes
+        mags = rawStars['mag_std_noabs'][:, 0].astype(np.float64) + offsets[0]
+        fluxes = (mags*units.ABmag).to_value(units.nJy)
+        fluxErrs = (np.log(10.) / 2.5) * fluxes * rawStars['magErr_std'][:, 0].astype(np.float64)
+        # Only check the first one
+        self.assertFloatsAlmostEqual(fluxes[0], refStruct.refCat['r_flux'][test[0]])
+        self.assertFloatsAlmostEqual(fluxErrs[0], refStruct.refCat['r_fluxErr'][test[0]])
+
         mag = rawStars['mag_std_noabs'][0, 0] + offsets[0]
         flux = (mag*units.ABmag).to_value(units.nJy)
         fluxErr = (np.log(10.) / 2.5) * flux * rawStars['magErr_std'][0, 0]

--- a/tests/fgcmcalTestBase.py
+++ b/tests/fgcmcalTestBase.py
@@ -320,12 +320,6 @@ class FgcmcalTestBase(object):
         self.assertFloatsAlmostEqual(fluxes[0], refStruct.refCat['r_flux'][test[0]])
         self.assertFloatsAlmostEqual(fluxErrs[0], refStruct.refCat['r_fluxErr'][test[0]])
 
-        mag = rawStars['mag_std_noabs'][0, 0] + offsets[0]
-        flux = (mag*units.ABmag).to_value(units.nJy)
-        fluxErr = (np.log(10.) / 2.5) * flux * rawStars['magErr_std'][0, 0]
-        self.assertFloatsAlmostEqual(flux, refStruct.refCat['r_flux'][test[0]], rtol=1e-6)
-        self.assertFloatsAlmostEqual(fluxErr, refStruct.refCat['r_fluxErr'][test[0]], rtol=1e-6)
-
         # Test the joincal_photoCalib output
 
         zptCat = butler.get('fgcmZeropoints', fgcmcycle=self.config.cycleNumber)


### PR DESCRIPTION
Ambiguities in how different version of numpy handled the implicit conversions
seemed to create problems in the round-trip mag-flux conversion tests.  By
being explicit with float64s in all cases this problem should go away.