### PR TITLE
DM-21814: Add tracking of calib_psfCandidate flags.

### DIFF
--- a/cookbook/fgcmFitCycleHscCookbook_cycle00_config.py
+++ b/cookbook/fgcmFitCycleHscCookbook_cycle00_config.py
@@ -40,7 +40,7 @@ config.aperCorrFitNBins = 0
 # Aperture correction input slope parameters.  There should be one slope ber band.
 # This is used when there is insufficient data to fit the parameters from the data
 # itself (e.g. tract mode or RC2).
-config.aperCorrInputParameters = (-1.0150, -0.9694, -1.7229, -1.4549, -1.1998)
+config.aperCorrInputSlopes = (-1.0150, -0.9694, -1.7229, -1.4549, -1.1998)
 # "Fudge factors" for computing SED slope
 # These are approximating by looking at stellar SED templates, and are the same
 # as used in DES calibrations (-E. Rykoff)

--- a/python/lsst/fgcmcal/fgcmBuildStars.py
+++ b/python/lsst/fgcmcal/fgcmBuildStars.py
@@ -143,6 +143,11 @@ class FgcmBuildStarsConfig(pexConfig.Config):
         dtype=str,
         default="base_Jacobian_value"
     )
+    psfCandidateName = pexConfig.Field(
+        doc="Name of field with psf candidate flag for propagation",
+        dtype=str,
+        default="calib_psfCandidate"
+    )
     sourceSelector = sourceSelectorRegistry.makeField(
         doc="How to select sources",
         default="science"
@@ -899,6 +904,8 @@ class FgcmBuildStarsTask(pipeBase.CmdLineTask):
                                 'jacobian')
         sourceMapper.addMapping(sourceSchema['slot_Centroid_x'].asKey(), 'x')
         sourceMapper.addMapping(sourceSchema['slot_Centroid_y'].asKey(), 'y')
+        sourceMapper.addMapping(sourceSchema[self.config.psfCandidateName].asKey(),
+                                'psf_candidate')
 
         # and add the fields we want
         sourceMapper.editOutputSchema().addField(

--- a/python/lsst/fgcmcal/fgcmBuildStars.py
+++ b/python/lsst/fgcmcal/fgcmBuildStars.py
@@ -146,7 +146,7 @@ class FgcmBuildStarsConfig(pexConfig.Config):
     psfCandidateName = pexConfig.Field(
         doc="Name of field with psf candidate flag for propagation",
         dtype=str,
-        default="calib_psfCandidate"
+        default="calib_psf_candidate"
     )
     sourceSelector = sourceSelectorRegistry.makeField(
         doc="How to select sources",

--- a/python/lsst/fgcmcal/fgcmCalibrateTract.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTract.py
@@ -82,6 +82,7 @@ class FgcmCalibrateTractConfig(pexConfig.Config):
         pexConfig.Config.setDefaults(self)
 
         self.fgcmBuildStars.checkAllCcds = False
+        self.fgcmBuildStars.densityCutMaxPerPixel = 10000
         self.fgcmFitCycle.useRepeatabilityForExpGrayCuts = True
         self.fgcmFitCycle.quietMode = True
         self.fgcmOutputProducts.doReferenceCalibration = False
@@ -312,6 +313,7 @@ class FgcmCalibrateTractTask(pipeBase.CmdLineTask):
                             fgcmStarIdCat['nObs'][:],
                             obsX=fgcmStarObservationCat['x'][obsIndex],
                             obsY=fgcmStarObservationCat['y'][obsIndex],
+                            psfCandidate=fgcmStarObservationCat['psf_candidate'][obsIndex],
                             refID=fgcmRefCat['fgcm_id'][:],
                             refMag=fgcmRefCat['refMag'][:, :],
                             refMagErr=fgcmRefCat['refMagErr'][:, :],

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -716,6 +716,7 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
                             starIds['nObs'][:],
                             obsX=starObs['x'][starIndices['obsIndex']],
                             obsY=starObs['y'][starIndices['obsIndex']],
+                            psfCandidate=starObs['psf_candidate'][starIndices['obsIndex']],
                             refID=refId,
                             refMag=refMag,
                             refMagErr=refMagErr,

--- a/python/lsst/fgcmcal/fgcmOutputProducts.py
+++ b/python/lsst/fgcmcal/fgcmOutputProducts.py
@@ -687,6 +687,8 @@ class FgcmOutputProductsTask(pipeBase.CmdLineTask):
         sourceMapper.addMinimalSchema(minSchema)
         for band in self.bands:
             sourceMapper.editOutputSchema().addField('%s_nGood' % (band), type=np.int32)
+            sourceMapper.editOutputSchema().addField('%s_nTotal' % (band), type=np.int32)
+            sourceMapper.editOutputSchema().addField('%s_nPsfCandidate' % (band), type=np.int32)
 
         formattedCat = afwTable.SimpleCatalog(sourceMapper.getOutputSchema())
         formattedCat.reserve(len(fgcmStarCat))
@@ -704,6 +706,8 @@ class FgcmOutputProductsTask(pipeBase.CmdLineTask):
             formattedCat['%s_flux' % (band)][:] = flux
             formattedCat['%s_fluxErr' % (band)][:] = fluxErr
             formattedCat['%s_nGood' % (band)][:] = fgcmStarCat['ngood'][:, b]
+            formattedCat['%s_nTotal' % (band)][:] = fgcmStarCat['ntotal'][:, b]
+            formattedCat['%s_nPsfCandidate' % (band)][:] = fgcmStarCat['npsfcand'][:, b]
 
         addRefCatMetadata(formattedCat)
 

--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -645,11 +645,16 @@ def makeStdSchema(nBands):
     stdSchema = afwTable.SimpleTable.makeMinimalSchema()
     stdSchema.addField('ngood', type='ArrayI', doc='Number of good observations',
                        size=nBands)
+    stdSchema.addField('ntotal', type='ArrayI', doc='Number of total observations',
+                       size=nBands)
     stdSchema.addField('mag_std_noabs', type='ArrayF',
                        doc='Standard magnitude (no absolute calibration)',
                        size=nBands)
     stdSchema.addField('magErr_std', type='ArrayF',
                        doc='Standard magnitude error',
+                       size=nBands)
+    stdSchema.addField('npsfcand', type='ArrayI',
+                       doc='Number of observations flagged as psf candidates',
                        size=nBands)
 
     return stdSchema
@@ -682,7 +687,9 @@ def makeStdCat(stdSchema, stdStruct):
     stdCat['coord_ra'][:] = stdStruct['RA'] * geom.degrees
     stdCat['coord_dec'][:] = stdStruct['DEC'] * geom.degrees
     stdCat['ngood'][:, :] = stdStruct['NGOOD'][:, :]
+    stdCat['ntotal'][:, :] = stdStruct['NTOTAL'][:, :]
     stdCat['mag_std_noabs'][:, :] = stdStruct['MAG_STD'][:, :]
     stdCat['magErr_std'][:, :] = stdStruct['MAGERR_STD'][:, :]
+    stdCat['npsfcand'][:, :] = stdStruct['NPSFCAND'][:, :]
 
     return stdCat

--- a/tests/fgcmcalTestBase.py
+++ b/tests/fgcmcalTestBase.py
@@ -320,6 +320,12 @@ class FgcmcalTestBase(object):
         self.assertFloatsAlmostEqual(fluxes[0], refStruct.refCat['r_flux'][test[0]])
         self.assertFloatsAlmostEqual(fluxErrs[0], refStruct.refCat['r_fluxErr'][test[0]])
 
+        # Test the psf candidate counting, ratio should be between 0.0 and 1.0
+        candRatio = (refStruct.refCat['r_nPsfCandidate'].astype(np.float64) /
+                     refStruct.refCat['r_nTotal'].astype(np.float64))
+        self.assertFloatsAlmostEqual(candRatio.min(), 0.0)
+        self.assertFloatsAlmostEqual(candRatio.max(), 1.0)
+
         # Test the joincal_photoCalib output
 
         zptCat = butler.get('fgcmZeropoints', fgcmcycle=self.config.cycleNumber)
@@ -466,7 +472,17 @@ class FgcmcalTestBase(object):
         # This will raise an exception if the catalog is not there.
         config = LoadIndexedReferenceObjectsConfig()
         config.ref_dataset_name = 'fgcm_stars_%d' % (tract)
-        task = LoadIndexedReferenceObjectsTask(butler, config=config)  # noqa F841
+        task = LoadIndexedReferenceObjectsTask(butler, config=config)
+
+        coord = geom.SpherePoint(320.0*geom.degrees, 0.0*geom.degrees)
+
+        refStruct = task.loadSkyCircle(coord, 5.0 * geom.degrees, filterName='r')
+
+        # Test the psf candidate counting, ratio should be between 0.0 and 1.0
+        candRatio = (refStruct.refCat['r_nPsfCandidate'].astype(np.float64) /
+                     refStruct.refCat['r_nTotal'].astype(np.float64))
+        self.assertFloatsAlmostEqual(candRatio.min(), 0.0)
+        self.assertFloatsAlmostEqual(candRatio.max(), 1.0)
 
     def _checkResult(self, result):
         """

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -240,6 +240,8 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         config.visitDataRefName = visitDataRefName
         config.ccdDataRefName = ccdDataRefName
         config.doReferenceMatches = True
+        # The testdata catalogs have the old name
+        config.psfCandidateName = 'calib_psfCandidate'
         config.fgcmLoadReferenceCatalog.refObjLoader.ref_dataset_name = 'sdss-dr9-fink-v5b'
         config.fgcmLoadReferenceCatalog.applyColorTerms = True
         config.fgcmLoadReferenceCatalog.colorterms = self.sdssColorterms()


### PR DESCRIPTION
Now fgcm will aggregate the stars that have the calib_psfCandidate flag and
count the number of times this is set (as well as the total number of
observations).  The output is in the final output refcat with the
band_nPsfCandidate field.