### PR TITLE
DM-20163: Use PixelAreaBoundedField in fgcmcal calibration outputs

### DIFF
--- a/python/lsst/fgcmcal/fgcmCalibrateTract.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTract.py
@@ -239,7 +239,8 @@ class FgcmCalibrateTractTask(pipeBase.CmdLineTask):
 
         # Note that we will need visitCat at the end of the procedure for the outputs
         groupedDataRefs = self.fgcmBuildStars.findAndGroupDataRefs(butler, dataRefs)
-        visitCat = self.fgcmBuildStars.fgcmMakeVisitCatalog(butler, groupedDataRefs)
+        camera = butler.get('camera')
+        visitCat = self.fgcmBuildStars.fgcmMakeVisitCatalog(camera, groupedDataRefs)
         fgcmStarObservationCat = self.fgcmBuildStars.fgcmMakeAllStarObservations(groupedDataRefs,
                                                                                  visitCat)
 
@@ -420,14 +421,12 @@ class FgcmCalibrateTractTask(pipeBase.CmdLineTask):
             rep = fgcmFitCycle.fgcmPars.compReservedRawRepeatability[i] * 1000.0
             self.log.info("  Band %s, repeatability: %.2f mmag" % (band, rep))
 
-        # Do the outputs.  Need to keep track of tract, blah.
+        # Do the outputs.  Need to keep track of tract.
 
-        if self.config.fgcmFitCycle.superStarSubCcd or self.config.fgcmFitCycle.ccdGraySubCcd:
-            chebSize = fgcmFitCycle.fgcmZpts.zpStruct['FGCM_FZPT_CHEB'].shape[1]
-        else:
-            chebSize = 0
+        superStarChebSize = fgcmFitCycle.fgcmZpts.zpStruct['FGCM_FZPT_SSTAR_CHEB'].shape[1]
+        zptChebSize = fgcmFitCycle.fgcmZpts.zpStruct['FGCM_FZPT_CHEB'].shape[1]
 
-        zptSchema = makeZptSchema(chebSize)
+        zptSchema = makeZptSchema(superStarChebSize, zptChebSize)
         zptCat = makeZptCat(zptSchema, fgcmFitCycle.fgcmZpts.zpStruct)
 
         atmSchema = makeAtmSchema()

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -432,6 +432,22 @@ class FgcmFitCycleConfig(pexConfig.Config):
         dtype=bool,
         default=False,
     )
+    autoPhotometricCutNSig = pexConfig.Field(
+        doc=("Number of sigma for automatic computation of (low) photometric cut. "
+             "Cut is based on exposure gray width (per band), unless "
+             "useRepeatabilityForExpGrayCuts is set, in which case the star "
+             "repeatability is used (also per band)."),
+        dtype=float,
+        default=3.0,
+    )
+    autoHighCutNSig = pexConfig.Field(
+        doc=("Number of sigma for automatic computation of (high) outlier cut. "
+             "Cut is based on exposure gray width (per band), unless "
+             "useRepeatabilityForExpGrayCuts is set, in which case the star "
+             "repeatability is used (also per band)."),
+        dtype=float,
+        default=4.0,
+    )
     quietMode = pexConfig.Field(
         doc="Be less verbose with logging.",
         dtype=bool,
@@ -1024,11 +1040,10 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
 
         # Save the zeropoint information and atmospheres only if desired
         if self.outputZeropoints:
-            if self.config.superStarSubCcd or self.config.ccdGraySubCcd:
-                chebSize = fgcmFitCycle.fgcmZpts.zpStruct['FGCM_FZPT_CHEB'].shape[1]
-            else:
-                chebSize = 0
-            zptSchema = makeZptSchema(chebSize)
+            superStarChebSize = fgcmFitCycle.fgcmZpts.zpStruct['FGCM_FZPT_SSTAR_CHEB'].shape[1]
+            zptChebSize = fgcmFitCycle.fgcmZpts.zpStruct['FGCM_FZPT_CHEB'].shape[1]
+
+            zptSchema = makeZptSchema(superStarChebSize, zptChebSize)
             zptCat = makeZptCat(zptSchema, fgcmFitCycle.fgcmZpts.zpStruct)
 
             butler.put(zptCat, 'fgcmZeropoints', fgcmcycle=self.config.cycleNumber)

--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -447,7 +447,7 @@ def computeCcdOffsets(camera, defaultOrientation):
 
 def computeReferencePixelScale(camera):
     """
-    Compute the average pixel scale in the camera
+    Compute the median pixel scale in the camera
 
     Returns
     -------

--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -31,6 +31,7 @@ import numpy as np
 import lsst.afw.cameraGeom as afwCameraGeom
 import lsst.afw.table as afwTable
 import lsst.afw.image as afwImage
+import lsst.afw.math as afwMath
 import lsst.geom as geom
 from lsst.obs.base import createInitialSkyWcs
 
@@ -48,7 +49,7 @@ def makeConfigDict(config, log, camera, maxIter,
         Configuration object
     log: `lsst.log.Log`
         LSST log object
-    camera: 'lsst.afw.cameraGeom.Camera`
+    camera: `lsst.afw.cameraGeom.Camera`
         Camera from the butler
     maxIter: `int`
         Maximum number of iterations
@@ -180,12 +181,15 @@ def makeConfigDict(config, log, camera, maxIter,
                   'instrumentSlopeMinDeltaT': config.instrumentSlopeMinDeltaT,
                   'fitMirrorChromaticity': config.fitMirrorChromaticity,
                   'useRepeatabilityForExpGrayCuts': config.useRepeatabilityForExpGrayCuts,
+                  'autoPhotometricCutNSig': config.autoPhotometricCutNSig,
+                  'autoHighCutNSig': config.autoHighCutNSig,
                   'printOnly': False,
                   'quietMode': config.quietMode,
                   'outputStars': False,
                   'clobber': True,
                   'useSedLUT': False,
                   'resetParameters': resetFitParameters,
+                  'outputFgcmcalZpts': True,  # when outputting zpts, use fgcmcal format
                   'outputZeropoints': outputZeropoints}
 
     return configDict
@@ -441,13 +445,88 @@ def computeCcdOffsets(camera, defaultOrientation):
     return ccdOffsets
 
 
-def makeZptSchema(chebyshevSize):
+def computeReferencePixelScale(camera):
+    """
+    Compute the average pixel scale in the camera
+
+    Returns
+    -------
+    pixelScale: `float`
+       Average pixel scale (arcsecond) over the camera
+    """
+
+    boresight = geom.SpherePoint(180.0*geom.degrees, 0.0*geom.degrees)
+    orientation = 0.0*geom.degrees
+    flipX = False
+
+    # Create a temporary visitInfo for input to createInitialSkyWcs
+    visitInfo = afwImage.VisitInfo(boresightRaDec=boresight,
+                                   boresightRotAngle=orientation,
+                                   rotType=afwImage.visitInfo.RotType.SKY)
+
+    pixelScales = np.zeros(len(camera))
+    for i, detector in enumerate(camera):
+        wcs = createInitialSkyWcs(visitInfo, detector, flipX)
+        pixelScales[i] = wcs.getPixelScale().asArcseconds()
+
+    ok, = np.where(pixelScales > 0.0)
+    return np.median(pixelScales[ok])
+
+
+def computeApproxPixelAreaFields(camera):
+    """
+    Compute the approximate pixel area bounded fields from the camera
+    geometry.
+
+    Parameters
+    ----------
+    camera: `lsst.afw.cameraGeom.Camera`
+
+    Returns
+    -------
+    approxPixelAreaFields: `dict`
+       Dictionary of approximate area fields, keyed with detector ID
+    """
+
+    areaScaling = 1. / computeReferencePixelScale(camera)**2.
+
+    # Generate fake WCSs centered at 180/0 to avoid the RA=0/360 problem,
+    # since we are looking for relative scales
+    boresight = geom.SpherePoint(180.0*geom.degrees, 0.0*geom.degrees)
+
+    flipX = False
+    # Create a temporary visitInfo for input to createInitialSkyWcs
+    # The orientation does not matter for the area computation
+    visitInfo = afwImage.VisitInfo(boresightRaDec=boresight,
+                                   boresightRotAngle=0.0*geom.degrees,
+                                   rotType=afwImage.visitInfo.RotType.SKY)
+
+    approxPixelAreaFields = {}
+
+    for i, detector in enumerate(camera):
+        key = detector.getId()
+
+        wcs = createInitialSkyWcs(visitInfo, detector, flipX)
+        bbox = detector.getBBox()
+
+        areaField = afwMath.PixelAreaBoundedField(bbox, wcs,
+                                                  unit=geom.arcseconds, scaling=areaScaling)
+        approxAreaField = afwMath.ChebyshevBoundedField.approximate(areaField)
+
+        approxPixelAreaFields[key] = approxAreaField
+
+    return approxPixelAreaFields
+
+
+def makeZptSchema(superStarChebyshevSize, zptChebyshevSize):
     """
     Make the zeropoint schema
 
     Parameters
     ----------
-    chebyshevSize: `int`
+    superStarChebyshevSize: `int`
+       Length of the superstar chebyshev array
+    zptChebyshevSize: `int`
        Length of the zeropoint chebyshev array
 
     Returns
@@ -469,12 +548,14 @@ def makeZptSchema(chebyshevSize):
     zptSchema.addField('fgcmZpt', type=np.float32, doc='FGCM zeropoint (center of CCD)')
     zptSchema.addField('fgcmZptErr', type=np.float32,
                        doc='Error on zeropoint, estimated from repeatability + number of obs')
-    if chebyshevSize > 0:
-        zptSchema.addField('fgcmfZptCheb', type='ArrayD',
-                           size=chebyshevSize,
-                           doc='Chebyshev parameters (flattened) for zeropoint')
-        zptSchema.addField('fgcmfZptChebXyMax', type='ArrayD', size=2,
-                           doc='maximum x/maximum y to scale to apply chebyshev parameters')
+    zptSchema.addField('fgcmfZptChebXyMax', type='ArrayD', size=2,
+                       doc='maximum x/maximum y to scale to apply chebyshev parameters')
+    zptSchema.addField('fgcmfZptCheb', type='ArrayD',
+                       size=zptChebyshevSize,
+                       doc='Chebyshev parameters (flattened) for zeropoint')
+    zptSchema.addField('fgcmfZptSstarCheb', type='ArrayD',
+                       size=superStarChebyshevSize,
+                       doc='Chebyshev parameters (flattened) for superStarFlat')
     zptSchema.addField('fgcmI0', type=np.float32, doc='Integral of the passband')
     zptSchema.addField('fgcmI10', type=np.float32, doc='Normalized chromatic integral')
     zptSchema.addField('fgcmR0', type=np.float32,
@@ -545,9 +626,9 @@ def makeZptCat(zptSchema, zpStruct):
     zptCat['fgcmFlag'][:] = zpStruct['FGCM_FLAG']
     zptCat['fgcmZpt'][:] = zpStruct['FGCM_ZPT']
     zptCat['fgcmZptErr'][:] = zpStruct['FGCM_ZPTERR']
-    if 'FGCM_FZPT_CHEB_XYMAX' in zpStruct.dtype.names:
-        zptCat['fgcmfZptCheb'][:, :] = zpStruct['FGCM_FZPT_CHEB']
-        zptCat['fgcmfZptChebXyMax'][:, :] = zpStruct['FGCM_FZPT_CHEB_XYMAX']
+    zptCat['fgcmfZptChebXyMax'][:, :] = zpStruct['FGCM_FZPT_XYMAX']
+    zptCat['fgcmfZptCheb'][:, :] = zpStruct['FGCM_FZPT_CHEB']
+    zptCat['fgcmfZptSstarCheb'][:, :] = zpStruct['FGCM_FZPT_SSTAR_CHEB']
     zptCat['fgcmI0'][:] = zpStruct['FGCM_I0']
     zptCat['fgcmI10'][:] = zpStruct['FGCM_I10']
     zptCat['fgcmR0'][:] = zpStruct['FGCM_R0']

--- a/tests/fgcmcalTestBase.py
+++ b/tests/fgcmcalTestBase.py
@@ -233,24 +233,24 @@ class FgcmcalTestBase(object):
         zps = butler.get('fgcmZeropoints', fgcmcycle=self.config.cycleNumber)
 
         # Check the numbers of zeropoints in all, good, okay, and bad
-        self.assertEqual(nZp, len(zps))
+        self.assertEqual(len(zps), nZp)
 
         gd, = np.where(zps['fgcmFlag'] == 1)
-        self.assertEqual(nGoodZp, len(gd))
+        self.assertEqual(len(gd), nGoodZp)
 
         ok, = np.where(zps['fgcmFlag'] < 16)
-        self.assertEqual(nOkZp, len(ok))
+        self.assertEqual(len(ok), nOkZp)
 
         bd, = np.where(zps['fgcmFlag'] >= 16)
-        self.assertEqual(nBadZp, len(bd))
+        self.assertEqual(len(bd), nBadZp)
 
         # Check that there are no illegal values with the ok zeropoints
         test, = np.where(zps['fgcmZpt'][gd] < -9000.0)
-        self.assertEqual(0, len(test))
+        self.assertEqual(len(test), 0)
 
         stds = butler.get('fgcmStandardStars', fgcmcycle=self.config.cycleNumber)
 
-        self.assertEqual(nStdStars, len(stds))
+        self.assertEqual(len(stds), nStdStars)
 
     def _testFgcmOutputProducts(self, visitDataRefName, ccdDataRefName, filterMapping,
                                 zpOffsets, testVisit, testCcd, testFilter, testBandIndex):
@@ -326,7 +326,7 @@ class FgcmcalTestBase(object):
         self.assertFloatsAlmostEqual(candRatio.min(), 0.0)
         self.assertFloatsAlmostEqual(candRatio.max(), 1.0)
 
-        # Test the joincal_photoCalib output
+        # Test the fgcm_photoCalib output
 
         zptCat = butler.get('fgcmZeropoints', fgcmcycle=self.config.cycleNumber)
         selected = (zptCat['fgcmFlag'] < 16)

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -103,7 +103,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         nGoodZp = 26
         nOkZp = 26
         nBadZp = 1206
-        nStdStars = 390
+        nStdStars = 389
         nPlots = 34
 
         self._testFgcmFitCycle(nZp, nGoodZp, nOkZp, nBadZp, nStdStars, nPlots, skipChecks=True)
@@ -140,7 +140,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.config.refObjLoader.ref_dataset_name = "sdss-dr9-fink-v5b"
 
         filterMapping = {'r': 'HSC-R', 'i': 'HSC-I'}
-        zpOffsets = np.array([-0.0013903317740, -0.0020539460238])
+        zpOffsets = np.array([-0.001367187476717, -0.0020010727458])
 
         self._testFgcmOutputProducts(visitDataRefName, ccdDataRefName,
                                      filterMapping, zpOffsets,
@@ -172,13 +172,13 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.fillDefaultBuildStarsConfig(self.config.fgcmBuildStars, visitDataRefName, ccdDataRefName)
         self.config.fgcmBuildStars.checkAllCcds = False
         self.fillDefaultFitCycleConfig(self.config.fgcmFitCycle)
-        self.config.maxFitCycles = 2
+        self.config.maxFitCycles = 3
 
         self.config.fgcmOutputProducts.doRefcatOutput = True
 
-        rawRepeatability = np.array([0.007070288705, 0.0074971053995])
-        filterNCalibMap = {'HSC-R': 13,
-                           'HSC-I': 13}
+        rawRepeatability = np.array([0.007167850226701, 0.00834175861044])
+        filterNCalibMap = {'HSC-R': 10,
+                           'HSC-I': 11}
 
         visits = [903334, 903336, 903338, 903342, 903344, 903346,
                   903986, 903988, 903990, 904010, 904014]
@@ -270,8 +270,11 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         config.washMjds = (0.0, )
         config.epochMjds = (0.0, 100000.0)
         config.latitude = 19.8256
-        config.expGrayPhotometricCut = (-0.05, -0.05)
-        config.expGrayHighCut = (0.2, 0.2)
+        config.expGrayPhotometricCut = (-0.1, -0.1)
+        config.expGrayHighCut = (0.1, 0.1)
+        config.expVarGrayPhotometricCut = 0.05**2.
+        config.autoPhotometricCutNSig = 5.0
+        config.autoHighCutNSig = 5.0
         config.aperCorrFitNBins = 0
         config.aperCorrInputSlopes = (-0.9694, -1.7229)
         config.sedFudgeFactors = (1.0, 1.0)


### PR DESCRIPTION
Use new features of afw, including `PixelAreaBoundedField` and `ProductBoundedField` to decompose photometric calibration into wcs jacobian component, star-flat (illumination correction) component, and gray component.