### PR TITLE
DM-23699: Update fgcmcal default config format

### DIFF
--- a/python/lsst/fgcmcal/fgcmCalibrateTract.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTract.py
@@ -83,7 +83,8 @@ class FgcmCalibrateTractConfig(pexConfig.Config):
 
         self.fgcmBuildStars.checkAllCcds = False
         self.fgcmBuildStars.densityCutMaxPerPixel = 10000
-        self.fgcmFitCycle.useRepeatabilityForExpGrayCuts = [True]
+        self.fgcmFitCycle.useRepeatabilityForExpGrayCutsDict = {b: True for
+                                                                b in self.fgcmFitCycle.bands}
         self.fgcmFitCycle.quietMode = True
         self.fgcmOutputProducts.doReferenceCalibration = False
         self.fgcmOutputProducts.doRefcatOutput = False

--- a/python/lsst/fgcmcal/fgcmCalibrateTract.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTract.py
@@ -83,13 +83,20 @@ class FgcmCalibrateTractConfig(pexConfig.Config):
 
         self.fgcmBuildStars.checkAllCcds = False
         self.fgcmBuildStars.densityCutMaxPerPixel = 10000
-        self.fgcmFitCycle.useRepeatabilityForExpGrayCutsDict = {b: True for
-                                                                b in self.fgcmFitCycle.bands}
         self.fgcmFitCycle.quietMode = True
         self.fgcmOutputProducts.doReferenceCalibration = False
         self.fgcmOutputProducts.doRefcatOutput = False
         self.fgcmOutputProducts.cycleNumber = 0
         self.fgcmOutputProducts.photoCal.applyColorTerms = False
+
+    def validate(self):
+        super().validate()
+
+        for band in self.fgcmFitCycle.bands:
+            if not self.fgcmFitCycle.useRepeatabilityForExpGrayCutsDict[band]:
+                msg = 'Must set useRepeatabilityForExpGrayCutsDict[band]=True for all bands'
+                raise pexConfig.FieldValidationError(FgcmFitCycleConfig.useRepeatabilityForExpGrayCutsDict,
+                                                     self, msg)
 
 
 class FgcmCalibrateTractRunner(pipeBase.ButlerInitializedTaskRunner):

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -69,6 +69,15 @@ class FgcmFitCycleConfig(pexConfig.Config):
              "and matched band-by-band."),
         dtype=int,
         default=(0,),
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use fitBands instead."),
+    )
+    fitBands = pexConfig.ListField(
+        doc=("Bands to use in atmospheric fit.  Other bands will have atmosphere constrained "
+             "from observations in the other bands on the same night."),
+        dtype=str,
+        default=[],
     )
     requiredFlag = pexConfig.ListField(
         doc=("Flag for which bands are required for a star to be considered a calibration "
@@ -76,6 +85,14 @@ class FgcmFitCycleConfig(pexConfig.Config):
              "be same length as config.bands, and matched band-by-band."),
         dtype=int,
         default=(0,),
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use requiredBands instead."),
+    )
+    requiredBands = pexConfig.ListField(
+        doc="Bands that are required for a star to be considered a calibration star.",
+        dtype=str,
+        default=[],
     )
     filterMap = pexConfig.DictField(
         doc="Mapping from 'filterName' to band.",
@@ -138,6 +155,15 @@ class FgcmFitCycleConfig(pexConfig.Config):
         doc="Compute superstar flat on sub-ccd scale",
         dtype=bool,
         default=True,
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use superStarSubCcdDict instead."),
+    )
+    superStarSubCcdDict = pexConfig.DictField(
+        doc="Per-band specification on whether to compute superstar flat on sub-ccd scale.",
+        keytype=str,
+        itemtype=bool,
+        default={},
     )
     superStarSubCcdChebyshevOrder = pexConfig.Field(
         doc=("Order of the 2D chebyshev polynomials for sub-ccd superstar fit. "
@@ -161,6 +187,15 @@ class FgcmFitCycleConfig(pexConfig.Config):
         doc="Compute CCD gray terms on sub-ccd scale",
         dtype=bool,
         default=False,
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use ccdGraySubCcdDict instead."),
+    )
+    ccdGraySubCcdDict = pexConfig.DictField(
+        doc="Per-band specification on whether to compute ccd gray on sub-ccd scale.",
+        keytype=str,
+        itemtype=bool,
+        default={},
     )
     ccdGraySubCcdChebyshevOrder = pexConfig.Field(
         doc="Order of the 2D chebyshev polynomials for sub-ccd gray fit.",
@@ -271,12 +306,32 @@ class FgcmFitCycleConfig(pexConfig.Config):
              "Must be same length as config.bands, and matched band-by-band."),
         dtype=float,
         default=(0.0,),
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use expGrayPhotometricCutDict instead."),
+    )
+    expGrayPhotometricCutDict = pexConfig.DictField(
+        doc=("Per-band specification on maximum (negative) exposure gray for a visit to be "
+             "considered photometric.  Must have one entry per band."),
+        keytype=str,
+        itemtype=float,
+        default={},
     )
     expGrayHighCut = pexConfig.ListField(
         doc=("Maximum (positive) exposure gray for a visit to be considered photometric. "
              "Must be same length as config.bands, and matched band-by-band."),
         dtype=float,
         default=(0.0,),
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use expGrayHighCutDict instead."),
+    )
+    expGrayHighCutDict = pexConfig.DictField(
+        doc=("Per-band specification on maximum (positive) exposure gray for a visit to be "
+             "considered photometric.  Must have one entry per band."),
+        keytype=str,
+        itemtype=float,
+        default={},
     )
     expGrayRecoverCut = pexConfig.Field(
         doc=("Maximum (negative) exposure gray to be able to recover bad ccds via interpolation. "
@@ -289,6 +344,16 @@ class FgcmFitCycleConfig(pexConfig.Config):
         doc="Maximum exposure variance to be considered possibly photometric",
         dtype=float,
         default=0.0005,
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use expVarGrayPhotometricCutDict instead."),
+    )
+    expVarGrayPhotometricCutDict = pexConfig.DictField(
+        doc=("Per-band specification on maximum exposure variance to be considered possibly "
+             "photometric."),
+        keytype=str,
+        itemtype=float,
+        default={},
     )
     expGrayErrRecoverCut = pexConfig.Field(
         doc=("Maximum exposure gray error to be able to recover bad ccds via interpolation. "
@@ -312,12 +377,26 @@ class FgcmFitCycleConfig(pexConfig.Config):
              "If set, must be same length as config.bands, and matched band-by-band."),
         dtype=float,
         default=[],
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use aperCorrInputSlopeDict instead."),
+    )
+    aperCorrInputSlopeDict = pexConfig.DictField(
+        doc=("Per-band specification of aperture correction input slope parameters.  These "
+             "are used on the first fit iteration, and aperture correction parameters will "
+             "be updated from the data if config.aperCorrFitNBins > 0.  It is recommended "
+             "to set this when there is insufficient data to fit the parameters (e.g. "
+             "tract mode)."),
+        keytype=str,
+        itemtype=float,
+        default={},
     )
     sedFudgeFactors = pexConfig.ListField(
         doc=("Fudge factors for computing linear SED from colors.  Must be same length as "
              "config.bands, and matched band-by-band."),
         dtype=float,
         default=(0,),
+        optional=True,
         deprecated=("This field has been deprecated and will be removed after v20. "
                     "Please use sedSlopeTermMap and sedSlopeMap."),
     )
@@ -339,6 +418,16 @@ class FgcmFitCycleConfig(pexConfig.Config):
              "May be 1 element (same for all bands) or the same length as config.bands."),
         dtype=float,
         default=(0.05,),
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use sigFgcmMaxEGrayDict instead."),
+    )
+    sigFgcmMaxEGrayDict = pexConfig.DictField(
+        doc=("Per-band specification for maximum (absolute) gray value for observations in "
+             "sigma_fgcm."),
+        keytype=str,
+        itemtype=float,
+        default={},
     )
     ccdGrayMaxStarErr = pexConfig.Field(
         doc="Maximum error on a star observation to use in ccd gray computation",
@@ -350,6 +439,16 @@ class FgcmFitCycleConfig(pexConfig.Config):
              "May be 1 element (same for all bands) or the same length as config.bands."),
         dtype=float,
         default=(1.0, ),
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use approxThroughputDict instead."),
+    )
+    approxThroughputDict = pexConfig.DictField(
+        doc=("Per-band specification of the approximate overall throughput at the start of "
+             "calibration observations."),
+        keytype=str,
+        itemtype=float,
+        default={},
     )
     sigmaCalRange = pexConfig.ListField(
         doc="Allowed range for systematic error floor estimation",
@@ -394,6 +493,14 @@ class FgcmFitCycleConfig(pexConfig.Config):
     colorSplitIndices = pexConfig.ListField(
         doc="Band indices to use to split stars by color",
         dtype=int,
+        default=None,
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use colorSplitBands instead."),
+    )
+    colorSplitBands = pexConfig.ListField(
+        doc="Band names to use to split stars by color.  Must have 2 entries.",
+        dtype=str,
         default=None,
     )
     modelMagErrors = pexConfig.Field(
@@ -445,6 +552,16 @@ class FgcmFitCycleConfig(pexConfig.Config):
              "May be 1 element (same for all bands) or the same length as config.bands."),
         dtype=bool,
         default=(False,),
+        optional=True,
+        deprecated=("This field is no longer used, and has been deprecated by DM-23699. "
+                    "It will be removed after v20.  Use useRepeatabilityForExpGrayCutsDict instead."),
+    )
+    useRepeatabilityForExpGrayCutsDict = pexConfig.DictField(
+        doc=("Per-band specification on whether to use star repeatability (instead of exposures) "
+             "for computing photometric cuts. Recommended for tract mode or bands with few visits."),
+        keytype=str,
+        itemtype=bool,
+        default={},
     )
     autoPhotometricCutNSig = pexConfig.Field(
         doc=("Number of sigma for automatic computation of (low) photometric cut. "
@@ -785,12 +902,17 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
         # Output the config for the next cycle
         # We need to make a copy since the input one has been frozen
 
+        updatedPhotometricCutDict = {b: float(fgcmFitCycle.updatedPhotometricCut[i]) for
+                                     i, b in enumerate(self.config.bands)}
+        updatedHighCutDict = {b: float(fgcmFitCycle.updatedHighCut[i]) for
+                              i, b in enumerate(self.config.bands)}
+
         outConfig = copy.copy(self.config)
         outConfig.update(cycleNumber=(self.config.cycleNumber + 1),
                          precomputeSuperStarInitialCycle=False,
                          freezeStdAtmosphere=False,
-                         expGrayPhotometricCut=fgcmFitCycle.updatedPhotometricCut,
-                         expGrayHighCut=fgcmFitCycle.updatedHighCut)
+                         expGrayPhotometricCutDict=updatedPhotometricCutDict,
+                         expGrayHighCutDict=updatedHighCutDict)
         configFileName = '%s_cycle%02d_config.py' % (outConfig.outfileBase,
                                                      outConfig.cycleNumber)
         outConfig.save(configFileName)
@@ -878,9 +1000,9 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
 
         inParInfo = np.zeros(1, dtype=[('NCCD', 'i4'),
                                        ('LUTFILTERNAMES', parLutFilterNames.dtype.str,
-                                        parLutFilterNames.size),
-                                       ('FITBANDS', parFitBands.dtype.str, parFitBands.size),
-                                       ('NOTFITBANDS', parNotFitBands.dtype.str, parNotFitBands.size),
+                                        (parLutFilterNames.size, )),
+                                       ('FITBANDS', parFitBands.dtype.str, (parFitBands.size, )),
+                                       ('NOTFITBANDS', parNotFitBands.dtype.str, (parNotFitBands.size, )),
                                        ('LNTAUUNIT', 'f8'),
                                        ('LNTAUSLOPEUNIT', 'f8'),
                                        ('ALPHAUNIT', 'f8'),
@@ -900,74 +1022,74 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
         inParInfo['HASEXTERNALPWV'] = parCat['hasExternalPwv']
         inParInfo['HASEXTERNALTAU'] = parCat['hasExternalTau']
 
-        inParams = np.zeros(1, dtype=[('PARALPHA', 'f8', parCat['parAlpha'].size),
-                                      ('PARO3', 'f8', parCat['parO3'].size),
+        inParams = np.zeros(1, dtype=[('PARALPHA', 'f8', (parCat['parAlpha'].size, )),
+                                      ('PARO3', 'f8', (parCat['parO3'].size, )),
                                       ('PARLNTAUINTERCEPT', 'f8',
-                                       parCat['parLnTauIntercept'].size),
+                                       (parCat['parLnTauIntercept'].size, )),
                                       ('PARLNTAUSLOPE', 'f8',
-                                       parCat['parLnTauSlope'].size),
+                                       (parCat['parLnTauSlope'].size, )),
                                       ('PARLNPWVINTERCEPT', 'f8',
-                                       parCat['parLnPwvIntercept'].size),
+                                       (parCat['parLnPwvIntercept'].size, )),
                                       ('PARLNPWVSLOPE', 'f8',
-                                       parCat['parLnPwvSlope'].size),
+                                       (parCat['parLnPwvSlope'].size, )),
                                       ('PARLNPWVQUADRATIC', 'f8',
-                                       parCat['parLnPwvQuadratic'].size),
+                                       (parCat['parLnPwvQuadratic'].size, )),
                                       ('PARQESYSINTERCEPT', 'f8',
-                                       parCat['parQeSysIntercept'].size),
+                                       (parCat['parQeSysIntercept'].size, )),
                                       ('COMPQESYSSLOPE', 'f8',
-                                       parCat['compQeSysSlope'].size),
+                                       (parCat['compQeSysSlope'].size, )),
                                       ('PARFILTEROFFSET', 'f8',
-                                       parCat['parFilterOffset'].size),
+                                       (parCat['parFilterOffset'].size, )),
                                       ('PARFILTEROFFSETFITFLAG', 'i2',
-                                       parCat['parFilterOffsetFitFlag'].size),
+                                       (parCat['parFilterOffsetFitFlag'].size, )),
                                       ('PARRETRIEVEDLNPWVSCALE', 'f8'),
                                       ('PARRETRIEVEDLNPWVOFFSET', 'f8'),
                                       ('PARRETRIEVEDLNPWVNIGHTLYOFFSET', 'f8',
-                                       parCat['parRetrievedLnPwvNightlyOffset'].size),
+                                       (parCat['parRetrievedLnPwvNightlyOffset'].size, )),
                                       ('COMPABSTHROUGHPUT', 'f8',
-                                       parCat['compAbsThroughput'].size),
+                                       (parCat['compAbsThroughput'].size, )),
                                       ('COMPREFOFFSET', 'f8',
-                                       parCat['compRefOffset'].size),
+                                       (parCat['compRefOffset'].size, )),
                                       ('COMPREFSIGMA', 'f8',
-                                       parCat['compRefSigma'].size),
+                                       (parCat['compRefSigma'].size, )),
                                       ('COMPMIRRORCHROMATICITY', 'f8',
-                                       parCat['compMirrorChromaticity'].size),
+                                       (parCat['compMirrorChromaticity'].size, )),
                                       ('MIRRORCHROMATICITYPIVOT', 'f8',
-                                       parCat['mirrorChromaticityPivot'].size),
+                                       (parCat['mirrorChromaticityPivot'].size, )),
                                       ('COMPAPERCORRPIVOT', 'f8',
-                                       parCat['compAperCorrPivot'].size),
+                                       (parCat['compAperCorrPivot'].size, )),
                                       ('COMPAPERCORRSLOPE', 'f8',
-                                       parCat['compAperCorrSlope'].size),
+                                       (parCat['compAperCorrSlope'].size, )),
                                       ('COMPAPERCORRSLOPEERR', 'f8',
-                                       parCat['compAperCorrSlopeErr'].size),
+                                       (parCat['compAperCorrSlopeErr'].size, )),
                                       ('COMPAPERCORRRANGE', 'f8',
-                                       parCat['compAperCorrRange'].size),
+                                       (parCat['compAperCorrRange'].size, )),
                                       ('COMPMODELERREXPTIMEPIVOT', 'f8',
-                                       parCat['compModelErrExptimePivot'].size),
+                                       (parCat['compModelErrExptimePivot'].size, )),
                                       ('COMPMODELERRFWHMPIVOT', 'f8',
-                                       parCat['compModelErrFwhmPivot'].size),
+                                       (parCat['compModelErrFwhmPivot'].size, )),
                                       ('COMPMODELERRSKYPIVOT', 'f8',
-                                       parCat['compModelErrSkyPivot'].size),
+                                       (parCat['compModelErrSkyPivot'].size, )),
                                       ('COMPMODELERRPARS', 'f8',
-                                       parCat['compModelErrPars'].size),
+                                       (parCat['compModelErrPars'].size, )),
                                       ('COMPEXPGRAY', 'f8',
-                                       parCat['compExpGray'].size),
+                                       (parCat['compExpGray'].size, )),
                                       ('COMPVARGRAY', 'f8',
-                                       parCat['compVarGray'].size),
+                                       (parCat['compVarGray'].size, )),
                                       ('COMPNGOODSTARPEREXP', 'i4',
-                                       parCat['compNGoodStarPerExp'].size),
+                                       (parCat['compNGoodStarPerExp'].size, )),
                                       ('COMPSIGFGCM', 'f8',
-                                       parCat['compSigFgcm'].size),
+                                       (parCat['compSigFgcm'].size, )),
                                       ('COMPSIGMACAL', 'f8',
-                                       parCat['compSigmaCal'].size),
+                                       (parCat['compSigmaCal'].size, )),
                                       ('COMPRETRIEVEDLNPWV', 'f8',
-                                       parCat['compRetrievedLnPwv'].size),
+                                       (parCat['compRetrievedLnPwv'].size, )),
                                       ('COMPRETRIEVEDLNPWVRAW', 'f8',
-                                       parCat['compRetrievedLnPwvRaw'].size),
+                                       (parCat['compRetrievedLnPwvRaw'].size, )),
                                       ('COMPRETRIEVEDLNPWVFLAG', 'i2',
-                                       parCat['compRetrievedLnPwvFlag'].size),
+                                       (parCat['compRetrievedLnPwvFlag'].size, )),
                                       ('COMPRETRIEVEDTAUNIGHT', 'f8',
-                                       parCat['compRetrievedTauNight'].size)])
+                                       (parCat['compRetrievedTauNight'].size, ))])
 
         inParams['PARALPHA'][:] = parCat['parAlpha'][0, :]
         inParams['PARO3'][:] = parCat['parO3'][0, :]

--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -68,13 +68,8 @@ def makeConfigDict(config, log, camera, maxIter,
     configDict: `dict`
         Configuration dictionary for fgcm
     """
-
-    fitFlag = np.array(config.fitFlag, dtype=np.bool)
-    requiredFlag = np.array(config.requiredFlag, dtype=np.bool)
-
-    fitBands = [b for i, b in enumerate(config.bands) if fitFlag[i]]
-    notFitBands = [b for i, b in enumerate(config.bands) if not fitFlag[i]]
-    requiredBands = [b for i, b in enumerate(config.bands) if requiredFlag[i]]
+    # Extract the bands that are _not_ being fit for fgcm configuration
+    notFitBands = [b for b in config.bands if b not in config.fitBands]
 
     # process the starColorCuts
     starColorCutList = []
@@ -113,9 +108,9 @@ def makeConfigDict(config, log, camera, maxIter,
                   'skyBrightnessField': 'SKYBACKGROUND',
                   'deepFlag': 'DEEPFLAG',  # unused
                   'bands': list(config.bands),
-                  'fitBands': list(fitBands),
-                  'notFitBands': list(notFitBands),
-                  'requiredBands': list(requiredBands),
+                  'fitBands': list(config.fitBands),
+                  'notFitBands': notFitBands,
+                  'requiredBands': list(config.requiredBands),
                   'filterToBand': dict(config.filterMap),
                   'logLevel': 'INFO',  # FIXME
                   'nCore': config.nCore,
@@ -124,11 +119,11 @@ def makeConfigDict(config, log, camera, maxIter,
                   'reserveFraction': config.reserveFraction,
                   'freezeStdAtmosphere': config.freezeStdAtmosphere,
                   'precomputeSuperStarInitialCycle': config.precomputeSuperStarInitialCycle,
-                  'superStarSubCCD': config.superStarSubCcd,
+                  'superStarSubCCDDict': dict(config.superStarSubCcdDict),
                   'superStarSubCCDChebyshevOrder': config.superStarSubCcdChebyshevOrder,
                   'superStarSubCCDTriangular': config.superStarSubCcdTriangular,
                   'superStarSigmaClip': config.superStarSigmaClip,
-                  'ccdGraySubCCD': config.ccdGraySubCcd,
+                  'ccdGraySubCCDDict': dict(config.ccdGraySubCcdDict),
                   'ccdGraySubCCDChebyshevOrder': config.ccdGraySubCcdChebyshevOrder,
                   'ccdGraySubCCDTriangular': config.ccdGraySubCcdTriangular,
                   'cycleNumber': config.cycleNumber,
@@ -146,10 +141,10 @@ def makeConfigDict(config, log, camera, maxIter,
                   'minStarPerExp': config.minStarPerExp,
                   'minExpPerNight': config.minExpPerNight,
                   'expGrayInitialCut': config.expGrayInitialCut,
-                  'expGrayPhotometricCut': np.array(config.expGrayPhotometricCut),
-                  'expGrayHighCut': np.array(config.expGrayHighCut),
+                  'expGrayPhotometricCutDict': dict(config.expGrayPhotometricCutDict),
+                  'expGrayHighCutDict': dict(config.expGrayHighCutDict),
                   'expGrayRecoverCut': config.expGrayRecoverCut,
-                  'expVarGrayPhotometricCut': config.expVarGrayPhotometricCut,
+                  'expVarGrayPhotometricCutDict': dict(config.expVarGrayPhotometricCutDict),
                   'expGrayErrRecoverCut': config.expGrayErrRecoverCut,
                   'refStarSnMin': config.refStarSnMin,
                   'refStarOutlierNSig': config.refStarOutlierNSig,
@@ -157,14 +152,14 @@ def makeConfigDict(config, log, camera, maxIter,
                   'illegalValue': -9999.0,  # internally used by fgcm.
                   'starColorCuts': starColorCutList,
                   'aperCorrFitNBins': config.aperCorrFitNBins,
-                  'aperCorrInputSlopes': np.array(config.aperCorrInputSlopes),
+                  'aperCorrInputSlopeDict': dict(config.aperCorrInputSlopeDict),
                   'sedBoundaryTermDict': config.sedboundaryterms.toDict()['data'],
                   'sedTermDict': config.sedterms.toDict()['data'],
-                  'colorSplitIndices': np.array(config.colorSplitIndices),
+                  'colorSplitBands': list(config.colorSplitBands),
                   'sigFgcmMaxErr': config.sigFgcmMaxErr,
-                  'sigFgcmMaxEGray': list(config.sigFgcmMaxEGray),
+                  'sigFgcmMaxEGrayDict': dict(config.sigFgcmMaxEGrayDict),
                   'ccdGrayMaxStarErr': config.ccdGrayMaxStarErr,
-                  'approxThroughput': list(config.approxThroughput),
+                  'approxThroughputDict': dict(config.approxThroughputDict),
                   'sigmaCalRange': list(config.sigmaCalRange),
                   'sigmaCalFitPercentile': list(config.sigmaCalFitPercentile),
                   'sigmaCalPlotPercentile': list(config.sigmaCalPlotPercentile),
@@ -183,7 +178,7 @@ def makeConfigDict(config, log, camera, maxIter,
                   'instrumentParsPerBand': config.instrumentParsPerBand,
                   'instrumentSlopeMinDeltaT': config.instrumentSlopeMinDeltaT,
                   'fitMirrorChromaticity': config.fitMirrorChromaticity,
-                  'useRepeatabilityForExpGrayCuts': list(config.useRepeatabilityForExpGrayCuts),
+                  'useRepeatabilityForExpGrayCutsDict': dict(config.useRepeatabilityForExpGrayCutsDict),
                   'autoPhotometricCutNSig': config.autoPhotometricCutNSig,
                   'autoHighCutNSig': config.autoHighCutNSig,
                   'printOnly': False,

--- a/tests/config/fgcmFitCycleHsc.py
+++ b/tests/config/fgcmFitCycleHsc.py
@@ -3,19 +3,23 @@ import lsst.fgcmcal as fgcmcal
 config.outfileBase = 'TestFgcm'
 config.filterMap = {'g': 'g', 'r': 'r', 'i': 'i'}
 config.bands = ['g', 'r', 'i']
-config.fitFlag = (1, 1, 1)
-config.requiredFlag = (0, 1, 1)
+config.fitBands = ['g', 'r', 'i']
+config.requiredBands = ['r', 'i']
 config.maxIterBeforeFinalCycle = 5
 config.nCore = 1
 config.washMjds = (0.0, )
 config.epochMjds = (0.0, 100000.0)
-config.expGrayPhotometricCut = (-0.1, -0.1, -0.1)
-config.expGrayHighCut = (0.1, 0.1, 0.1)
-config.expVarGrayPhotometricCut = 0.05**2.
+config.expGrayPhotometricCutDict = {'g': -0.1, 'r': -0.1, 'i': -0.1}
+config.expGrayHighCutDict = {'g': 0.1, 'r': 0.1, 'i': 0.1}
+config.expVarGrayPhotometricCutDict = {'g': 0.05**2.,
+                                       'r': 0.05**2.,
+                                       'i': 0.05**2.}
 config.autoPhotometricCutNSig = 5.0
 config.autoHighCutNSig = 5.0
 config.aperCorrFitNBins = 2
-config.aperCorrInputSlopes = (-1.0, -0.9694, -1.7229)
+config.aperCorrInputSlopeDict = {'g': -1.0,
+                                 'r': -0.9694,
+                                 'i': -1.7229}
 config.sedboundaryterms = fgcmcal.SedboundarytermDict()
 config.sedboundaryterms.data['ri'] = fgcmcal.Sedboundaryterm(primary='r',
                                                              secondary='i')
@@ -32,11 +36,12 @@ config.minExpPerNight = 1
 config.minStarPerExp = 50
 config.nStarPerRun = 50
 config.nExpPerRun = 2
-config.colorSplitIndices = (1, 2)
+config.colorSplitBands = ['r', 'i']
 config.superStarSubCcdChebyshevOrder = 1
-config.ccdGraySubCcd = False
+config.ccdGraySubCcdDict = {'g': False,
+                            'r': False,
+                            'i': False}
 config.modelMagErrors = False
 config.sigmaCalRange = (0.003, 0.003)
 config.instrumentParsPerBand = False
-config.useRepeatabilityForExpGrayCuts = (False, False, False)
-config.sigFgcmMaxEGray = (0.05, 0.05, 0.05)
+

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -177,8 +177,8 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.otherArgs = []
 
         rawRepeatability = np.array([0.0, 0.00691888829016613, 0.00443888382172])
-        filterNCalibMap = {'HSC-R': 13,
-                           'HSC-I': 14}
+        filterNCalibMap = {'HSC-R': 17,
+                           'HSC-I': 16}
 
         visits = [903334, 903336, 903338, 903342, 903344, 903346,
                   903986, 903988, 903990, 904010, 904014]

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -128,7 +128,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         # Test the "final" fit cycle
         newConfig = copy.copy(self.config)
         newConfig.update(cycleNumber=2,
-                         ccdGraySubCcd=True,
+                         ccdGraySubCcdDict={'g': True, 'r': True, 'i': True},
                          isFinalCycle=True)
         self.config = newConfig
 

--- a/tests/test_fitcycle.py
+++ b/tests/test_fitcycle.py
@@ -1,0 +1,95 @@
+# See COPYRIGHT file at the top of the source tree.
+#
+# This file is part of fgcmcal.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Test the fitcycle configurations
+"""
+
+import unittest
+import copy
+
+import lsst.fgcmcal as fgcmcal
+import lsst.utils
+
+
+class FgcmcalTestFitCycleConfig(lsst.utils.tests.TestCase):
+    """
+    Test FgcmFitCycleConfig validation.
+    """
+    def test_fgcmfitcycle_config_validation(self):
+        """
+        Test the FgcmFitCycleConfig validation.
+        """
+        config = fgcmcal.FgcmFitCycleConfig()
+
+        config.cycleNumber = 0
+        config.utBoundary = 0.0
+        config.latitude = 0.0
+        config.outfileBase = 'None'
+        config.bands = ['r', 'i']
+        config.fitBands = ['r', 'i']
+        config.requiredBands = ['r']
+        config.colorSplitBands = ['r', 'i']
+        config.superStarSubCcdDict = {'r': True, 'i': True}
+        config.ccdGraySubCcdDict = {'r': True, 'i': True}
+        config.expGrayPhotometricCutDict = {'r': -0.05, 'i': -0.05}
+        config.expGrayHighCutDict = {'r': 0.10, 'i': 0.10}
+        config.expVarGrayPhotometricCutDict = {'r': 0.0005, 'i': 0.0005}
+        config.sigFgcmMaxEGrayDict = {'r': 0.05, 'i': 0.05}
+        config.approxThroughputDict = {'r': 1.0, 'i': 1.0}
+        config.useRepeatabilityForExpGrayCutsDict = {'r': False, 'i': False}
+
+        # Ensure that it validates
+        config.validate()
+
+        self._test_misconfig(config, 'fitBands', ['r', 'i', 'z'])
+        self._test_misconfig(config, 'requiredBands', ['r', 'i', 'z'])
+        self._test_misconfig(config, 'colorSplitBands', ['r', 'z'])
+        self._test_misconfig(config, 'superStarSubCcdDict', {'r': True})
+        self._test_misconfig(config, 'ccdGraySubCcdDict', {'r': True})
+        self._test_misconfig(config, 'expGrayPhotometricCutDict', {'r': -0.05})
+        self._test_misconfig(config, 'expGrayHighCutDict', {'r': 0.10})
+        self._test_misconfig(config, 'expVarGrayPhotometricCutDict', {'r': 0.0005})
+        self._test_misconfig(config, 'sigFgcmMaxEGrayDict', {'r': 0.05})
+        self._test_misconfig(config, 'approxThroughputDict', {'r': 1.0})
+        self._test_misconfig(config, 'useRepeatabilityForExpGrayCutsDict', {'r': False})
+
+    def _test_misconfig(self, config, field, value):
+        """
+        Test misconfigured field.
+        """
+        config2 = copy.copy(config)
+        config2.update(**{field: value})
+        with self.assertRaises(ValueError):
+            config2.validate()
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
All list fields which depended on getting the band order correct have been
deprecated and replaced with dict mappings to avoid many possible index
errors.  This is supported with 3.2.0 version of fgcm.  Additional
FutureWarnings from numpy 1.17 have also been fixed.