### PR TITLE
DM-25114: Update internal fgcm math to always use 64-bit floats

### DIFF
--- a/python/lsst/fgcmcal/fgcmCalibrateTract.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTract.py
@@ -352,14 +352,13 @@ class FgcmCalibrateTractTask(pipeBase.CmdLineTask):
                             flagFlag=None,
                             computeNobs=True)
 
-        fgcmFitCycle.setLUT(fgcmLut)
-        fgcmFitCycle.setStars(fgcmStars)
-
         # Clear out some memory
-        # del fgcmStarObservationCat
         del fgcmStarIdCat
         del fgcmStarIndicesCat
         del fgcmRefCat
+
+        fgcmFitCycle.setLUT(fgcmLut)
+        fgcmFitCycle.setStars(fgcmStars, fgcmPars)
 
         converged = False
         cycleNumber = 0

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -871,6 +871,7 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
             flagId = flaggedStars['objId'][:]
             flagFlag = flaggedStars['objFlag'][:]
         else:
+            flaggedStars = None
             flagId = None
             flagFlag = None
 
@@ -882,6 +883,7 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
                                                      self.config.filterMap)
             refId = refStars['fgcm_id'][:]
         else:
+            refStars = None
             refId = None
             refMag = None
             refMagErr = None
@@ -927,17 +929,20 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
                             computeNobs=True)
 
         # Release all references to temporary objects holding star data (see above)
-        starObs = None
-        starIds = None
-        starIndices = None
-        flagId = None
-        flagFlag = None
-        flaggedStars = None
-        refStars = None
+        del starObs
+        del starIds
+        del starIndices
+        del flagId
+        del flagFlag
+        del flaggedStars
+        del refStars
+        del refId
+        del refMag
+        del refMagErr
 
         # and set the bits in the cycle object
         fgcmFitCycle.setLUT(fgcmLut)
-        fgcmFitCycle.setStars(fgcmStars)
+        fgcmFitCycle.setStars(fgcmStars, fgcmPars)
         fgcmFitCycle.setPars(fgcmPars)
 
         # finish the setup

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -1049,13 +1049,11 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
 
         parLutFilterNames = np.array(parCat[0]['lutFilterNames'].split(','))
         parFitBands = np.array(parCat[0]['fitBands'].split(','))
-        parNotFitBands = np.array(parCat[0]['notFitBands'].split(','))
 
         inParInfo = np.zeros(1, dtype=[('NCCD', 'i4'),
                                        ('LUTFILTERNAMES', parLutFilterNames.dtype.str,
                                         (parLutFilterNames.size, )),
                                        ('FITBANDS', parFitBands.dtype.str, (parFitBands.size, )),
-                                       ('NOTFITBANDS', parNotFitBands.dtype.str, (parNotFitBands.size, )),
                                        ('LNTAUUNIT', 'f8'),
                                        ('LNTAUSLOPEUNIT', 'f8'),
                                        ('ALPHAUNIT', 'f8'),
@@ -1071,7 +1069,6 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
         inParInfo['NCCD'] = parCat['nCcd']
         inParInfo['LUTFILTERNAMES'][:] = parLutFilterNames
         inParInfo['FITBANDS'][:] = parFitBands
-        inParInfo['NOTFITBANDS'][:] = parNotFitBands
         inParInfo['HASEXTERNALPWV'] = parCat['hasExternalPwv']
         inParInfo['HASEXTERNALTAU'] = parCat['hasExternalTau']
 
@@ -1207,14 +1204,12 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
                                           for n in parInfo['LUTFILTERNAMES'][0]])
         fitBandString = comma.join([n.decode('utf-8')
                                     for n in parInfo['FITBANDS'][0]])
-        notFitBandString = comma.join([n.decode('utf-8')
-                                       for n in parInfo['NOTFITBANDS'][0]])
 
         parSchema = self._makeParSchema(parInfo, pars, fgcmFitCycle.fgcmPars.parSuperStarFlat,
-                                        lutFilterNameString, fitBandString, notFitBandString)
+                                        lutFilterNameString, fitBandString)
         parCat = self._makeParCatalog(parSchema, parInfo, pars,
                                       fgcmFitCycle.fgcmPars.parSuperStarFlat,
-                                      lutFilterNameString, fitBandString, notFitBandString)
+                                      lutFilterNameString, fitBandString)
 
         butler.put(parCat, 'fgcmFitParameters', fgcmcycle=self.config.cycleNumber)
 
@@ -1253,7 +1248,7 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
             butler.put(stdCat, 'fgcmStandardStars', fgcmcycle=self.config.cycleNumber)
 
     def _makeParSchema(self, parInfo, pars, parSuperStarFlat,
-                       lutFilterNameString, fitBandString, notFitBandString):
+                       lutFilterNameString, fitBandString):
         """
         Make the parameter persistence schema
 
@@ -1269,8 +1264,6 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
            Combined string of all the lutFilterNames
         fitBandString: `str`
            Combined string of all the fitBands
-        notFitBandString: `str`
-           Combined string of all the bands not used in the fit
 
         Returns
         -------
@@ -1285,8 +1278,6 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
                            size=len(lutFilterNameString))
         parSchema.addField('fitBands', type=str, doc='Bands that were fit',
                            size=len(fitBandString))
-        parSchema.addField('notFitBands', type=str, doc='Bands that were not fit',
-                           size=len(notFitBandString))
         parSchema.addField('lnTauUnit', type=np.float64, doc='Step units for ln(AOD)')
         parSchema.addField('lnTauSlopeUnit', type=np.float64,
                            doc='Step units for ln(AOD) slope')
@@ -1395,7 +1386,7 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
         return parSchema
 
     def _makeParCatalog(self, parSchema, parInfo, pars, parSuperStarFlat,
-                        lutFilterNameString, fitBandString, notFitBandString):
+                        lutFilterNameString, fitBandString):
         """
         Make the FGCM parameter catalog for persistence
 
@@ -1411,8 +1402,6 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
            Combined string of all the lutFilterNames
         fitBandString: `str`
            Combined string of all the fitBands
-        notFitBandString: `str`
-           Combined string of all the bands not used in the fit
 
         Returns
         -------
@@ -1431,7 +1420,6 @@ class FgcmFitCycleTask(pipeBase.CmdLineTask):
         rec['nCcd'] = parInfo['NCCD']
         rec['lutFilterNames'] = lutFilterNameString
         rec['fitBands'] = fitBandString
-        rec['notFitBands'] = notFitBandString
         # note these are not currently supported here.
         rec['hasExternalPwv'] = 0
         rec['hasExternalTau'] = 0

--- a/tests/fgcmcalTestBase.py
+++ b/tests/fgcmcalTestBase.py
@@ -299,10 +299,7 @@ class FgcmcalTestBase(object):
         # Extract the offsets from the results
         offsets = result.resultList[0].results.offsets
 
-        # The tolerance here has been loosened to account for different
-        # results on different platforms.
-        # TODO: Tighten tolerances with fixes in DM-25114
-        self.assertFloatsAlmostEqual(offsets, zpOffsets, atol=1e-5)
+        self.assertFloatsAlmostEqual(offsets, zpOffsets, atol=1e-6)
 
         butler = dafPersist.butler.Butler(self.testDir)
 
@@ -481,11 +478,8 @@ class FgcmcalTestBase(object):
         os.chdir(cwd)
 
         # Check that the converged repeatability is what we expect
-        # The tolerance here has been loosened to account for different
-        # results on different platforms.
-        # TODO: Tighten tolerances with fixes in DM-25114
         repeatability = result.resultList[0].results.repeatability
-        self.assertFloatsAlmostEqual(repeatability, rawRepeatability, atol=3e-3)
+        self.assertFloatsAlmostEqual(repeatability, rawRepeatability, atol=1e-6)
 
         butler = dafPersist.butler.Butler(self.testDir)
 

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -150,7 +150,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.otherArgs = []
 
         filterMapping = {'r': 'HSC-R', 'i': 'HSC-I'}
-        zpOffsets = np.array([0.0012975315330550075, 0.006424360908567905])
+        zpOffsets = np.array([0.00129685504, 0.006424042396])
 
         self._testFgcmOutputProducts(visitDataRefName, ccdDataRefName,
                                      filterMapping, zpOffsets,
@@ -179,7 +179,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.configfiles = [testConfigFile]
         self.otherArgs = []
 
-        rawRepeatability = np.array([0.0, 0.012838834334716097, 0.008774119602231331])
+        rawRepeatability = np.array([0.0, 0.00456888661, 0.00878837692])
         filterNCalibMap = {'HSC-R': 14,
                            'HSC-I': 15}
 


### PR DESCRIPTION
Also tighten test tolerances now that various platforms give consistent results at the <1e-6 level.