### PR TITLE
DM-26085: Fix fgcmcal zeropoint offset due to background offset.

### DIFF
--- a/python/lsst/fgcmcal/fgcmBuildStarsBase.py
+++ b/python/lsst/fgcmcal/fgcmBuildStarsBase.py
@@ -599,6 +599,8 @@ class FgcmBuildStarsBaseTask(pipeBase.CmdLineTask, abc.ABC):
             "instMagErr", type=np.float32, doc="Instrumental magnitude error")
         sourceMapper.editOutputSchema().addField(
             "jacobian", type=np.float32, doc="Relative pixel scale from wcs jacobian")
+        sourceMapper.editOutputSchema().addField(
+            "deltaMagBkg", type=np.float32, doc="Change in magnitude due to local background offset")
 
         return sourceMapper
 

--- a/python/lsst/fgcmcal/fgcmCalibrateTractBase.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTractBase.py
@@ -325,6 +325,7 @@ class FgcmCalibrateTractBaseTask(pipeBase.CmdLineTask):
                             fgcmStarIdCat['nObs'][:],
                             obsX=fgcmStarObservationCat['x'][obsIndex],
                             obsY=fgcmStarObservationCat['y'][obsIndex],
+                            obsDeltaMagBkg=fgcmStarObservationCat['deltaMagBkg'][obsIndex],
                             psfCandidate=fgcmStarObservationCat['psf_candidate'][obsIndex],
                             refID=refId,
                             refMag=refMag,

--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -126,6 +126,8 @@ def makeConfigDict(config, log, camera, maxIter,
                   'ccdGraySubCCDTriangular': config.ccdGraySubCcdTriangular,
                   'cycleNumber': config.cycleNumber,
                   'maxIter': maxIter,
+                  'deltaMagBkgOffsetPercentile': config.deltaMagBkgOffsetPercentile,
+                  'deltaMagBkgPerCcd': config.deltaMagBkgPerCcd,
                   'UTBoundary': config.utBoundary,
                   'washMJDs': config.washMjds,
                   'epochMJDs': config.epochMjds,
@@ -560,7 +562,10 @@ def makeZptSchema(superStarChebyshevSize, zptChebyshevSize):
                        doc='Retrieved i10 integral, estimated from stars (only for flag 1)')
     zptSchema.addField('fgcmGry', type=np.float64,
                        doc='Estimated gray extinction relative to atmospheric solution; '
-                       'only for flag <= 4')
+                       'only for fgcmFlag <= 4 (see fgcmFlag) ')
+    zptSchema.addField('fgcmDeltaChrom', type=np.float64,
+                       doc='Mean chromatic correction for stars in this ccd; '
+                       'only for fgcmFlag <= 4 (see fgcmFlag)')
     zptSchema.addField('fgcmZptVar', type=np.float64, doc='Variance of zeropoint over ccd')
     zptSchema.addField('fgcmTilings', type=np.float64,
                        doc='Number of photometric tilings used for solution for ccd')
@@ -587,6 +592,10 @@ def makeZptSchema(superStarChebyshevSize, zptChebyshevSize):
                        'at the time of the exposure')
     zptSchema.addField('fgcmFlat', type=np.float64, doc='Superstarflat illumination correction')
     zptSchema.addField('fgcmAperCorr', type=np.float64, doc='Aperture correction estimated by fgcm')
+    zptSchema.addField('fgcmDeltaMagBkg', type=np.float64,
+                       doc=('Local background correction from brightest percentile '
+                            '(value set by deltaMagBkgOffsetPercentile) calibration '
+                            'stars.'))
     zptSchema.addField('exptime', type=np.float32, doc='Exposure time')
     zptSchema.addField('filtername', type=str, size=10, doc='Filter name')
 
@@ -630,6 +639,7 @@ def makeZptCat(zptSchema, zpStruct):
     zptCat['fgcmR0'][:] = zpStruct['FGCM_R0']
     zptCat['fgcmR10'][:] = zpStruct['FGCM_R10']
     zptCat['fgcmGry'][:] = zpStruct['FGCM_GRY']
+    zptCat['fgcmDeltaChrom'][:] = zpStruct['FGCM_DELTACHROM']
     zptCat['fgcmZptVar'][:] = zpStruct['FGCM_ZPTVAR']
     zptCat['fgcmTilings'][:] = zpStruct['FGCM_TILINGS']
     zptCat['fgcmFpGry'][:] = zpStruct['FGCM_FPGRY']
@@ -641,6 +651,7 @@ def makeZptCat(zptSchema, zpStruct):
     zptCat['fgcmDust'][:] = zpStruct['FGCM_DUST']
     zptCat['fgcmFlat'][:] = zpStruct['FGCM_FLAT']
     zptCat['fgcmAperCorr'][:] = zpStruct['FGCM_APERCORR']
+    zptCat['fgcmDeltaMagBkg'][:] = zpStruct['FGCM_DELTAMAGBKG']
     zptCat['exptime'][:] = zpStruct['EXPTIME']
 
     return zptCat

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -95,8 +95,8 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
 
         visits = [34648, 34690, 34714, 34674, 34670, 36140, 35892, 36192, 36260, 36236]
 
-        nStar = 304
-        nObs = 3799
+        nStar = 305
+        nObs = 3789
 
         self._testFgcmBuildStarsTable(visits, nStar, nObs)
 
@@ -118,8 +118,8 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         nGoodZp = 27
         nOkZp = 27
         nBadZp = 1093
-        nStdStars = 252
-        nPlots = 40
+        nStdStars = 257
+        nPlots = 35
 
         self._testFgcmFitCycle(nZp, nGoodZp, nOkZp, nBadZp, nStdStars, nPlots, skipChecks=True)
 
@@ -157,7 +157,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.otherArgs = []
 
         filterMapping = {'r': 'HSC-R', 'i': 'HSC-I'}
-        zpOffsets = np.array([-0.0010568995494, 0.00553833786398])
+        zpOffsets = np.array([-0.003520437516272068, 0.005638898815959692])
 
         self._testFgcmOutputProducts(visitDataRefName, ccdDataRefName,
                                      filterMapping, zpOffsets,
@@ -186,7 +186,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         self.configfiles = [testConfigFile]
         self.otherArgs = []
 
-        rawRepeatability = np.array([0.0, 0.007815538231, 0.0099641318989])
+        rawRepeatability = np.array([0.0, 0.00976151819391, 0.004126379444775])
         filterNCalibMap = {'HSC-R': 14,
                            'HSC-I': 15}
 


### PR DESCRIPTION
The local background subtraction code has been refactored to move the
computations into the fgcm code.  This allows fgcm to compute background offset
statistics and account for any net offsets in the zeropoints.  The chromatic
correction code has been updated to report the average chromatic correction per
ccd.  This yields better repeatability when the full pipeline does not include
chromatic terms (as is the case currently).  Additional tests have been added
to check for remaining net offsets and ensure they are small (<2 mmag).