### PR TITLE
DM-29299: Clean up physicalFilterMap and fix background retrieval

### DIFF
--- a/python/lsst/fgcmcal/fgcmBuildStarsTable.py
+++ b/python/lsst/fgcmcal/fgcmBuildStarsTable.py
@@ -372,6 +372,10 @@ class FgcmBuildStarsTableTask(FgcmBuildStarsBaseTask):
                     # Not found
                     continue
 
+                # Make sure the dataset exists
+                if not calexpRef.datasetExists():
+                    continue
+
                 # It was found.  Add and quit out, since we only
                 # need one calexp per visit.
                 groupedDataRefs[visit].append(calexpRef)

--- a/python/lsst/fgcmcal/fgcmCalibrateTractBase.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTractBase.py
@@ -376,7 +376,9 @@ class FgcmCalibrateTractBaseTask(pipeBase.PipelineTask, pipeBase.CmdLineTask, ab
 
         configDict = makeConfigDict(self.config.fgcmFitCycle, self.log, dataRefDict['camera'],
                                     self.config.fgcmFitCycle.maxIterBeforeFinalCycle,
-                                    True, False, tract=tract)
+                                    True, False, lutIndexVals[0]['FILTERNAMES'],
+                                    tract=tract)
+
         # Turn off plotting in tract mode
         configDict['doPlots'] = False
 

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -1082,14 +1082,15 @@ class FgcmFitCycleTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             self.outputZeropoints = True
             self.resetFitParameters = False
 
-        configDict = makeConfigDict(self.config, self.log, camera,
-                                    self.maxIter, self.resetFitParameters,
-                                    self.outputZeropoints)
-
         lutCat = dataRefDict['fgcmLookUpTable'].get()
         fgcmLut, lutIndexVals, lutStd = translateFgcmLut(lutCat,
                                                          dict(self.config.physicalFilterMap))
         del lutCat
+
+        configDict = makeConfigDict(self.config, self.log, camera,
+                                    self.maxIter, self.resetFitParameters,
+                                    self.outputZeropoints,
+                                    lutIndexVals[0]['FILTERNAMES'])
 
         # next we need the exposure/visit information
         visitCat = dataRefDict['fgcmVisitCatalog'].get()

--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -66,7 +66,7 @@ def makeConfigDict(config, log, camera, maxIter,
     outputZeropoints: `bool`
         Compute zeropoints for output?
     lutFilterNames : array-like, `str`
-        Array of physical filter names in the LUT
+        Array of physical filter names in the LUT.
     tract: `int`, optional
         Tract number for extending the output file name for debugging.
         Default is None.

--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -46,7 +46,8 @@ FGCM_CCD_FIELD = 'DETECTOR'
 
 
 def makeConfigDict(config, log, camera, maxIter,
-                   resetFitParameters, outputZeropoints, tract=None):
+                   resetFitParameters, outputZeropoints,
+                   lutFilterNames, tract=None):
     """
     Make the FGCM fit cycle configuration dict
 
@@ -64,6 +65,8 @@ def makeConfigDict(config, log, camera, maxIter,
         Reset fit parameters before fitting?
     outputZeropoints: `bool`
         Compute zeropoints for output?
+    lutFilterNames : array-like, `str`
+        Array of physical filter names in the LUT
     tract: `int`, optional
         Tract number for extending the output file name for debugging.
         Default is None.
@@ -91,6 +94,10 @@ def makeConfigDict(config, log, camera, maxIter,
     gains = [amp.getGain() for detector in camera for amp in detector.getAmplifiers()]
     cameraGain = float(np.median(gains))
 
+    # Cut down the filter map to those that are in the LUT
+    filterToBand = {filterName: config.physicalFilterMap[filterName] for
+                    filterName in lutFilterNames}
+
     if tract is None:
         outfileBase = config.outfileBase
     else:
@@ -116,7 +123,7 @@ def makeConfigDict(config, log, camera, maxIter,
                   'fitBands': list(config.fitBands),
                   'notFitBands': notFitBands,
                   'requiredBands': list(config.requiredBands),
-                  'filterToBand': dict(config.physicalFilterMap),
+                  'filterToBand': filterToBand,
                   'logLevel': 'INFO',
                   'nCore': config.nCore,
                   'nStarPerRun': config.nStarPerRun,
@@ -231,9 +238,8 @@ def translateFgcmLut(lutCat, physicalFilterMap):
     """
 
     # first we need the lutIndexVals
-    # dtype is set for py2/py3/fits/fgcm compatibility
-    lutFilterNames = np.array(lutCat[0]['physicalFilters'].split(','), dtype='a')
-    lutStdFilterNames = np.array(lutCat[0]['stdPhysicalFilters'].split(','), dtype='a')
+    lutFilterNames = np.array(lutCat[0]['physicalFilters'].split(','), dtype='U')
+    lutStdFilterNames = np.array(lutCat[0]['stdPhysicalFilters'].split(','), dtype='U')
 
     # Note that any discrepancies between config values will raise relevant
     # exceptions in the FGCM code.

--- a/tests/config/fgcmFitCycleHsc.py
+++ b/tests/config/fgcmFitCycleHsc.py
@@ -1,6 +1,8 @@
 import lsst.fgcmcal as fgcmcal
 
 config.outfileBase = 'TestFgcm'
+# The unused z-band is here to test the case that extra filters
+# are in the map that are not used in the calibrations.
 config.physicalFilterMap = {'HSC-G': 'g',
                             'HSC-R': 'r',
                             'HSC-I': 'i',

--- a/tests/config/fgcmFitCycleHsc.py
+++ b/tests/config/fgcmFitCycleHsc.py
@@ -1,7 +1,10 @@
 import lsst.fgcmcal as fgcmcal
 
 config.outfileBase = 'TestFgcm'
-config.physicalFilterMap = {'HSC-G': 'g', 'HSC-R': 'r', 'HSC-I': 'i'}
+config.physicalFilterMap = {'HSC-G': 'g',
+                            'HSC-R': 'r',
+                            'HSC-I': 'i',
+                            'HSC-Z': 'z'}
 config.bands = ['g', 'r', 'i']
 config.fitBands = ['g', 'r', 'i']
 config.requiredBands = ['r', 'i']


### PR DESCRIPTION
This fixes two bugs.  The first is that the fgcm filterToBand expects no extra filters, so the full physicalFilterMap needs to be pruned.  The second is the background detector retrieval in gen3.