### PR TITLE
DM-29348: Add ability to run global fgcmcal in a single pipeline.

### DIFF
--- a/python/lsst/fgcmcal/fgcmCalibrateTractBase.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTractBase.py
@@ -81,6 +81,7 @@ class FgcmCalibrateTractConfigBase(pexConfig.Config):
         pexConfig.Config.setDefaults(self)
 
         self.fgcmFitCycle.quietMode = True
+        self.fgcmFitCycle.doPlots = False
         self.fgcmOutputProducts.doReferenceCalibration = False
         self.fgcmOutputProducts.doRefcatOutput = False
         self.fgcmOutputProducts.cycleNumber = 0
@@ -378,9 +379,6 @@ class FgcmCalibrateTractBaseTask(pipeBase.PipelineTask, pipeBase.CmdLineTask, ab
                                     self.config.fgcmFitCycle.maxIterBeforeFinalCycle,
                                     True, False, lutIndexVals[0]['FILTERNAMES'],
                                     tract=tract)
-
-        # Turn off plotting in tract mode
-        configDict['doPlots'] = False
 
         # Use the first orientation.
         # TODO: DM-21215 will generalize to arbitrary camera orientations

--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -25,6 +25,7 @@ and do not need to be part of a task.
 """
 
 import numpy as np
+import os
 import re
 
 from lsst.daf.base import PropertyList
@@ -36,7 +37,6 @@ import lsst.afw.math as afwMath
 import lsst.geom as geom
 from lsst.obs.base import createInitialSkyWcs
 from lsst.obs.base import Instrument
-
 
 import fgcm
 
@@ -203,9 +203,11 @@ def makeConfigDict(config, log, camera, maxIter,
                   'quietMode': config.quietMode,
                   'randomSeed': config.randomSeed,
                   'outputStars': False,
+                  'outputPath': os.path.abspath('.'),
                   'clobber': True,
                   'useSedLUT': False,
                   'resetParameters': resetFitParameters,
+                  'doPlots': config.doPlots,
                   'outputFgcmcalZpts': True,  # when outputting zpts, use fgcmcal format
                   'outputZeropoints': outputZeropoints}
 

--- a/tests/config/fgcmBuildStarsHsc.py
+++ b/tests/config/fgcmBuildStarsHsc.py
@@ -1,4 +1,3 @@
-config.physicalFilterMap = {'HSC-G': 'g', 'HSC-R': 'r', 'HSC-I': 'i'}
 config.requiredBands = ['r', 'i']
 config.primaryBands = ['i']
 config.minPerBand = 2

--- a/tests/config/fgcmFitCycleHsc.py
+++ b/tests/config/fgcmFitCycleHsc.py
@@ -1,12 +1,6 @@
 import lsst.fgcmcal as fgcmcal
 
 config.outfileBase = 'TestFgcm'
-# The unused z-band is here to test the case that extra filters
-# are in the map that are not used in the calibrations.
-config.physicalFilterMap = {'HSC-G': 'g',
-                            'HSC-R': 'r',
-                            'HSC-I': 'i',
-                            'HSC-Z': 'z'}
 config.bands = ['g', 'r', 'i']
 config.fitBands = ['g', 'r', 'i']
 config.requiredBands = ['r', 'i']

--- a/tests/pipelines/fgcmFullPipelineHsc.yaml
+++ b/tests/pipelines/fgcmFullPipelineHsc.yaml
@@ -1,0 +1,14 @@
+description: Full fgcmcal pipeline
+instrument: lsst.obs.subaru.HyperSuprimeCam
+tasks:
+  fgcmBuildStarsTable:
+    class: lsst.fgcmcal.fgcmBuildStarsTable.FgcmBuildStarsTableTask
+  fgcmFitCycle:
+    class: lsst.fgcmcal.fgcmFitCycle.FgcmFitCycleTask
+    config:
+      doMultipleCycles: true
+      multipleCyclesFinalCycleNumber: 2
+  fgcmOutputProducts:
+    class: lsst.fgcmcal.fgcmOutputProducts.FgcmOutputProductsTask
+    config:
+      doRefcatOutput: false


### PR DESCRIPTION
`FgcmFitCycleTask` has been updated to allow multiple fit cycles to be run at once.  This, in turn, allows the full fgcmcal (build stars; multiple fit cycles; output photoCalibs) to be run as a single pipeline.  The gen3 tests now share a common test repo.