### PR TITLE
DM-29535: Create gen3 cfht testdata_jointcal repos

### DIFF
--- a/tests/test_apertures.py
+++ b/tests/test_apertures.py
@@ -44,7 +44,7 @@ class FgcmApertureTest(lsst.utils.tests.TestCase):
         """
         lsst.log.setLevel("HscMapper", lsst.log.FATAL)
 
-        butler = dafPersist.Butler(os.path.join(self.dataDir, 'hsc'))
+        butler = dafPersist.Butler(os.path.join(self.dataDir, 'hsc/repo'))
 
         dataRef = butler.dataRef('src', visit=34648, ccd=51)
 

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -59,7 +59,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         cls.testDir = tempfile.mkdtemp(dir=ROOT, prefix="TestFgcm-")
 
         cls._importRepository('lsst.obs.subaru.HyperSuprimeCam',
-                              os.path.join(cls.dataDir, 'hsc'),
+                              os.path.join(cls.dataDir, 'hsc/repo'),
                               os.path.join(cls.dataDir, 'hsc', 'exports.yaml'))
 
     def test_fgcmcalPipeline(self):

--- a/tests/test_fgcmcal_hsc_gen2.py
+++ b/tests/test_fgcmcal_hsc_gen2.py
@@ -56,7 +56,7 @@ class FgcmcalTestHSCGen2(fgcmcalTestBaseGen2.FgcmcalTestBaseGen2, lsst.utils.tes
             raise unittest.SkipTest("obs_subaru not setup")
 
     def setUp(self):
-        inputDir = os.path.join(self.dataDir, 'hsc')
+        inputDir = os.path.join(self.dataDir, 'hsc/repo')
 
         self.testDir = tempfile.mkdtemp(dir=ROOT, prefix="TestFgcm-")
 

--- a/tests/test_focalPlaneProjector.py
+++ b/tests/test_focalPlaneProjector.py
@@ -53,7 +53,7 @@ class FgcmFocalPlaneProjectorTestHsc(fgcmcalTestBase.FgcmcalTestBase, lsst.utils
         cls.testDir = tempfile.mkdtemp(dir=ROOT, prefix="TestFgcm-")
 
         cls._importRepository('lsst.obs.subaru.HyperSuprimeCam',
-                              os.path.join(cls.dataDir, 'hsc'),
+                              os.path.join(cls.dataDir, 'hsc/repo'),
                               os.path.join(cls.dataDir, 'hsc', 'exports.yaml'))
 
     def test_focalPlaneProjector(self):

--- a/tests/test_loadref_hsc.py
+++ b/tests/test_loadref_hsc.py
@@ -50,7 +50,7 @@ class FgcmLoadReferenceTestHSC(lsst.utils.tests.TestCase):
             raise unittest.SkipTest("obs_subaru not setup")
 
     def setUp(self):
-        self.inputDir = os.path.join(self.dataDir, 'hsc')
+        self.inputDir = os.path.join(self.dataDir, 'hsc/repo')
 
         lsst.log.setLevel("HscMapper", lsst.log.FATAL)
 


### PR DESCRIPTION
As part of creating the gen3 cfht testdata, I reorganized the hsc data; this makes fgcmcal work with it.