### PR TITLE
DM-24738: Add background offset tracking to fgcmcal

### DIFF
--- a/python/lsst/fgcmcal/fgcmBuildStarsBase.py
+++ b/python/lsst/fgcmcal/fgcmBuildStarsBase.py
@@ -681,6 +681,8 @@ class FgcmBuildStarsBaseTask(pipeBase.PipelineTask, pipeBase.CmdLineTask, abc.AB
             "jacobian", type=np.float32, doc="Relative pixel scale from wcs jacobian")
         sourceMapper.editOutputSchema().addField(
             "deltaMagBkg", type=np.float32, doc="Change in magnitude due to local background offset")
+        sourceMapper.editOutputSchema().addField(
+            "deltaMagAper", type=np.float32, doc="Change in magnitude from larger to smaller aperture")
 
         return sourceMapper
 

--- a/python/lsst/fgcmcal/fgcmCalibrateTractBase.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTractBase.py
@@ -435,6 +435,7 @@ class FgcmCalibrateTractBaseTask(pipeBase.PipelineTask, pipeBase.CmdLineTask, ab
                             obsX=fgcmStarObservationCat['x'][obsIndex],
                             obsY=fgcmStarObservationCat['y'][obsIndex],
                             obsDeltaMagBkg=fgcmStarObservationCat['deltaMagBkg'][obsIndex],
+                            obsDeltaAper=fgcmStarObservationCat['deltaMagAper'][obsIndex],
                             psfCandidate=fgcmStarObservationCat['psf_candidate'][obsIndex],
                             refID=refId,
                             refMag=refMag,

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -757,6 +757,62 @@ class FgcmFitCycleConfig(pipeBase.PipelineTaskConfig,
         default=None,
         optional=True,
     )
+    deltaAperFitMinNgoodObs = pexConfig.Field(
+        doc="Minimum number of good observations to use mean delta-aper values in fits.",
+        dtype=int,
+        default=2,
+    )
+    deltaAperFitPerCcdNx = pexConfig.Field(
+        doc=("Number of x bins per ccd when computing delta-aper background offsets. "
+             "Only used when ``doComputeDeltaAperPerCcd`` is True."),
+        dtype=int,
+        default=10,
+    )
+    deltaAperFitPerCcdNy = pexConfig.Field(
+        doc=("Number of y bins per ccd when computing delta-aper background offsets. "
+             "Only used when ``doComputeDeltaAperPerCcd`` is True."),
+        dtype=int,
+        default=10,
+    )
+    deltaAperFitSpatialNside = pexConfig.Field(
+        doc="Healpix nside to compute spatial delta-aper background offset maps.",
+        dtype=int,
+        default=64,
+    )
+    deltaAperInnerRadiusArcsec = pexConfig.Field(
+        doc=("Inner radius used to compute deltaMagAper (arcseconds). "
+             "If set to 0.0 then output will be ``unnormalized`` units."),
+        dtype=float,
+        default=0.0,
+    )
+    deltaAperOuterRadiusArcsec = pexConfig.Field(
+        doc=("Outer radius used to compute deltaMagAper (arcseconds). "
+             "If set to 0.0 then output will be ``unnormalized`` units."),
+        dtype=float,
+        default=0.0,
+    )
+    doComputeDeltaAperPerVisit = pexConfig.Field(
+        doc=("Do the computation of delta-aper background offsets per visit? "
+             "Note: this option can be very slow when there are many visits."),
+        dtype=bool,
+        default=False,
+    )
+    doComputeDeltaAperPerStar = pexConfig.Field(
+        doc="Do the computation of delta-aper mean values per star?",
+        dtype=bool,
+        default=True,
+    )
+    doComputeDeltaAperMap = pexConfig.Field(
+        doc=("Do the computation of delta-aper spatial maps? "
+             "This is only used if ``doComputeDeltaAperPerStar`` is True,"),
+        dtype=bool,
+        default=False,
+    )
+    doComputeDeltaAperPerCcd = pexConfig.Field(
+        doc="Do the computation of per-ccd delta-aper background offsets?",
+        dtype=bool,
+        default=False,
+    )
 
     def validate(self):
         super().validate()
@@ -1203,6 +1259,7 @@ class FgcmFitCycleTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                             obsX=starObs['x'][starIndices['obsIndex']],
                             obsY=starObs['y'][starIndices['obsIndex']],
                             obsDeltaMagBkg=starObs['deltaMagBkg'][starIndices['obsIndex']],
+                            obsDeltaAper=starObs['deltaMagAper'][starIndices['obsIndex']],
                             psfCandidate=starObs['psf_candidate'][starIndices['obsIndex']],
                             refID=refId,
                             refMag=refMag,

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -1493,7 +1493,21 @@ class FgcmFitCycleTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                                       ('COMPRETRIEVEDLNPWVFLAG', 'i2',
                                        (parCat['compRetrievedLnPwvFlag'].size, )),
                                       ('COMPRETRIEVEDTAUNIGHT', 'f8',
-                                       (parCat['compRetrievedTauNight'].size, ))])
+                                       (parCat['compRetrievedTauNight'].size, )),
+                                      ('COMPEPSILON', 'f8',
+                                       (parCat['compEpsilon'].size, )),
+                                      ('COMPMEDDELTAAPER', 'f8',
+                                       (parCat['compMedDeltaAper'].size, )),
+                                      ('COMPGLOBALEPSILON', 'f4',
+                                       (parCat['compGlobalEpsilon'].size, )),
+                                      ('COMPEPSILONMAP', 'f4',
+                                       (parCat['compEpsilonMap'].size, )),
+                                      ('COMPEPSILONNSTARMAP', 'i4',
+                                       (parCat['compEpsilonNStarMap'].size, )),
+                                      ('COMPEPSILONCCDMAP', 'f4',
+                                       (parCat['compEpsilonCcdMap'].size, )),
+                                      ('COMPEPSILONCCDNSTARMAP', 'i4',
+                                       (parCat['compEpsilonCcdNStarMap'].size, ))])
 
         inParams['PARALPHA'][:] = parCat['parAlpha'][0, :]
         inParams['PARO3'][:] = parCat['parO3'][0, :]
@@ -1533,6 +1547,13 @@ class FgcmFitCycleTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         inParams['COMPRETRIEVEDLNPWVRAW'][:] = parCat['compRetrievedLnPwvRaw'][0, :]
         inParams['COMPRETRIEVEDLNPWVFLAG'][:] = parCat['compRetrievedLnPwvFlag'][0, :]
         inParams['COMPRETRIEVEDTAUNIGHT'][:] = parCat['compRetrievedTauNight'][0, :]
+        inParams['COMPEPSILON'][:] = parCat['compEpsilon'][0, :]
+        inParams['COMPMEDDELTAAPER'][:] = parCat['compMedDeltaAper'][0, :]
+        inParams['COMPGLOBALEPSILON'][:] = parCat['compGlobalEpsilon'][0, :]
+        inParams['COMPEPSILONMAP'][:] = parCat['compEpsilonMap'][0, :]
+        inParams['COMPEPSILONNSTARMAP'][:] = parCat['compEpsilonNStarMap'][0, :]
+        inParams['COMPEPSILONCCDMAP'][:] = parCat['compEpsilonCcdMap'][0, :]
+        inParams['COMPEPSILONCCDNSTARMAP'][:] = parCat['compEpsilonCcdNStarMap'][0, :]
 
         inSuperStar = np.zeros(parCat['superstarSize'][0, :], dtype='f8')
         inSuperStar[:, :, :, :] = parCat['superstar'][0, :].reshape(inSuperStar.shape)
@@ -1741,6 +1762,27 @@ class FgcmFitCycleTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                            size=pars['COMPRETRIEVEDLNPWVFLAG'].size)
         parSchema.addField('compRetrievedTauNight', type='ArrayD', doc='Retrieved tau (per night)',
                            size=pars['COMPRETRIEVEDTAUNIGHT'].size)
+        parSchema.addField('compEpsilon', type='ArrayD',
+                           doc='Computed epsilon background offset per visit (nJy/arcsec2)',
+                           size=pars['COMPEPSILON'].size)
+        parSchema.addField('compMedDeltaAper', type='ArrayD',
+                           doc='Median delta mag aper per visit',
+                           size=pars['COMPMEDDELTAAPER'].size)
+        parSchema.addField('compGlobalEpsilon', type='ArrayD',
+                           doc='Computed epsilon bkg offset (global) (nJy/arcsec2)',
+                           size=pars['COMPGLOBALEPSILON'].size)
+        parSchema.addField('compEpsilonMap', type='ArrayD',
+                           doc='Computed epsilon maps (nJy/arcsec2)',
+                           size=pars['COMPEPSILONMAP'].size)
+        parSchema.addField('compEpsilonNStarMap', type='ArrayI',
+                           doc='Number of stars per pixel in computed epsilon maps',
+                           size=pars['COMPEPSILONNSTARMAP'].size)
+        parSchema.addField('compEpsilonCcdMap', type='ArrayD',
+                           doc='Computed epsilon ccd maps (nJy/arcsec2)',
+                           size=pars['COMPEPSILONCCDMAP'].size)
+        parSchema.addField('compEpsilonCcdNStarMap', type='ArrayI',
+                           doc='Number of stars per ccd bin in epsilon ccd maps',
+                           size=pars['COMPEPSILONCCDNSTARMAP'].size)
         # superstarflat section
         parSchema.addField('superstarSize', type='ArrayI', doc='Superstar matrix size',
                            size=4)
@@ -1805,7 +1847,9 @@ class FgcmFitCycleTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                     'compExpGray', 'compVarGray', 'compNGoodStarPerExp', 'compSigFgcm',
                     'compSigmaCal', 'compExpDeltaMagBkg', 'compMedianSedSlope',
                     'compRetrievedLnPwv', 'compRetrievedLnPwvRaw', 'compRetrievedLnPwvFlag',
-                    'compRetrievedTauNight']
+                    'compRetrievedTauNight', 'compEpsilon', 'compMedDeltaAper',
+                    'compGlobalEpsilon', 'compEpsilonMap', 'compEpsilonNStarMap',
+                    'compEpsilonCcdMap', 'compEpsilonCcdNStarMap']
 
         for scalarName in scalarNames:
             rec[scalarName] = pars[scalarName.upper()]
@@ -1815,7 +1859,7 @@ class FgcmFitCycleTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
 
         # superstar section
         rec['superstarSize'][:] = parSuperStarFlat.shape
-        rec['superstar'][:] = parSuperStarFlat.flatten()
+        rec['superstar'][:] = parSuperStarFlat.ravel()
 
         return parCat
 

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -781,13 +781,17 @@ class FgcmFitCycleConfig(pipeBase.PipelineTaskConfig,
     )
     deltaAperInnerRadiusArcsec = pexConfig.Field(
         doc=("Inner radius used to compute deltaMagAper (arcseconds). "
-             "If set to 0.0 then output will be ``unnormalized`` units."),
+             "Must be positive and less than ``deltaAperOuterRadiusArcsec`` if "
+             "any of ``doComputeDeltaAperPerVisit``, ``doComputeDeltaAperPerStar``, "
+             "``doComputeDeltaAperMap``, ``doComputeDeltaAperPerCcd`` are set."),
         dtype=float,
         default=0.0,
     )
     deltaAperOuterRadiusArcsec = pexConfig.Field(
         doc=("Outer radius used to compute deltaMagAper (arcseconds). "
-             "If set to 0.0 then output will be ``unnormalized`` units."),
+             "Must be positive and greater than ``deltaAperInnerRadiusArcsec`` if "
+             "any of ``doComputeDeltaAperPerVisit``, ``doComputeDeltaAperPerStar``, "
+             "``doComputeDeltaAperMap``, ``doComputeDeltaAperPerCcd`` are set."),
         dtype=float,
         default=0.0,
     )
@@ -868,6 +872,22 @@ class FgcmFitCycleConfig(pipeBase.PipelineTaskConfig,
             if band not in self.useRepeatabilityForExpGrayCutsDict:
                 msg = 'band %s not in useRepeatabilityForExpGrayCutsDict' % (band)
                 raise pexConfig.FieldValidationError(FgcmFitCycleConfig.useRepeatabilityForExpGrayCutsDict,
+                                                     self, msg)
+
+        if self.doComputeDeltaAperPerVisit or self.doComputeDeltaAperMap \
+           or self.doComputeDeltaAperPerCcd:
+            if self.deltaAperInnerRadiusArcsec <= 0.0:
+                msg = 'deltaAperInnerRadiusArcsec must be positive if deltaAper computations are turned on.'
+                raise pexConfig.FieldValidationError(FgcmFitCycleConfig.deltaAperInnerRadiusArcsec,
+                                                     self, msg)
+            if self.deltaAperOuterRadiusArcsec <= 0.0:
+                msg = 'deltaAperOuterRadiusArcsec must be positive if deltaAper computations are turned on.'
+                raise pexConfig.FieldValidationError(FgcmFitCycleConfig.deltaAperOuterRadiusArcsec,
+                                                     self, msg)
+            if self.deltaAperOuterRadiusArcsec <= self.deltaAperInnerRadiusArcsec:
+                msg = ('deltaAperOuterRadiusArcsec must be greater than deltaAperInnerRadiusArcsec if '
+                       'deltaAper computations are turned on.')
+                raise pexConfig.FieldValidationError(FgcmFitCycleConfig.deltaAperOuterRadiusArcsec,
                                                      self, msg)
 
 

--- a/python/lsst/fgcmcal/focalPlaneProjector.py
+++ b/python/lsst/fgcmcal/focalPlaneProjector.py
@@ -83,7 +83,7 @@ class FocalPlaneProjector(object):
 
         return wcsDict
 
-    def __call__(self, orientation, nstep=50, use_cache=True):
+    def __call__(self, orientation, nstep=100, use_cache=True):
         """
         Make a focal plane projection mapping for use with fgcm.
 

--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -202,6 +202,16 @@ def makeConfigDict(config, log, camera, maxIter,
                   'useRepeatabilityForExpGrayCutsDict': dict(config.useRepeatabilityForExpGrayCutsDict),
                   'autoPhotometricCutNSig': config.autoPhotometricCutNSig,
                   'autoHighCutNSig': config.autoHighCutNSig,
+                  'deltaAperInnerRadiusArcsec': config.deltaAperInnerRadiusArcsec,
+                  'deltaAperOuterRadiusArcsec': config.deltaAperOuterRadiusArcsec,
+                  'deltaAperFitMinNgoodObs': config.deltaAperFitMinNgoodObs,
+                  'deltaAperFitPerCcdNx': config.deltaAperFitPerCcdNx,
+                  'deltaAperFitPerCcdNy': config.deltaAperFitPerCcdNy,
+                  'deltaAperFitSpatialNside': config.deltaAperFitSpatialNside,
+                  'doComputeDeltaAperExposures': config.doComputeDeltaAperPerVisit,
+                  'doComputeDeltaAperStars': config.doComputeDeltaAperPerStar,
+                  'doComputeDeltaAperMap': config.doComputeDeltaAperMap,
+                  'doComputeDeltaAperPerCcd': config.doComputeDeltaAperPerCcd,
                   'printOnly': False,
                   'quietMode': config.quietMode,
                   'randomSeed': config.randomSeed,
@@ -767,6 +777,9 @@ def makeStdSchema(nBands):
     stdSchema.addField('npsfcand', type='ArrayI',
                        doc='Number of observations flagged as psf candidates',
                        size=nBands)
+    stdSchema.addField('delta_aper', type='ArrayF',
+                       doc='Delta mag (small - large aperture)',
+                       size=nBands)
 
     return stdSchema
 
@@ -801,6 +814,7 @@ def makeStdCat(stdSchema, stdStruct, goodBands):
     stdCat['mag_std_noabs'][:, :] = stdStruct['MAG_STD'][:, :]
     stdCat['magErr_std'][:, :] = stdStruct['MAGERR_STD'][:, :]
     stdCat['npsfcand'][:, :] = stdStruct['NPSFCAND'][:, :]
+    stdCat['delta_aper'][:, :] = stdStruct['DELTA_APER'][:, :]
 
     md = PropertyList()
     md.set("BANDS", list(goodBands))

--- a/tests/config/fgcmFitCycleHsc.py
+++ b/tests/config/fgcmFitCycleHsc.py
@@ -94,3 +94,11 @@ config.sigFgcmMaxEGrayDict = {'g': 0.05,
 config.approxThroughputDict = {'g': 1.0,
                               'r': 1.0,
                               'i': 1.0}
+
+config.deltaAperFitPerCcdNx = 2
+config.deltaAperFitPerCcdNy = 4
+config.deltaAperInnerRadiusArcsec = 2.04
+config.deltaAperOuterRadiusArcsec = 2.89
+config.doComputeDeltaAperPerVisit = True
+config.doComputeDeltaAperMap = True
+config.doComputeDeltaAperPerCcd = True

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -92,7 +92,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         nOkZp = 27
         nBadZp = 1093
         nStdStars = 235
-        nPlots = 35
+        nPlots = 43
 
         self._testFgcmFitCycle(instName, testName,
                                0, nZp, nGoodZp, nOkZp, nBadZp, nStdStars, nPlots, skipChecks=True)

--- a/tests/test_fgcmcal_hsc_gen2.py
+++ b/tests/test_fgcmcal_hsc_gen2.py
@@ -118,7 +118,7 @@ class FgcmcalTestHSCGen2(fgcmcalTestBaseGen2.FgcmcalTestBaseGen2, lsst.utils.tes
         nOkZp = 27
         nBadZp = 1093
         nStdStars = 235
-        nPlots = 35
+        nPlots = 43
 
         self._testFgcmFitCycle(nZp, nGoodZp, nOkZp, nBadZp, nStdStars, nPlots, skipChecks=True)
 

--- a/tests/test_fitcycle.py
+++ b/tests/test_fitcycle.py
@@ -73,6 +73,12 @@ class FgcmcalTestFitCycleConfig(lsst.utils.tests.TestCase):
         self._test_misconfig(config, 'approxThroughputDict', {'r': 1.0})
         self._test_misconfig(config, 'useRepeatabilityForExpGrayCutsDict', {'r': False})
 
+        config.doComputeDeltaAperMap = True
+        self._test_misconfig(config, 'deltaAperInnerRadiusArcsec', 0.0)
+        config.deltaAperInnerRadiusArcsec = 1.0
+        self._test_misconfig(config, 'deltaAperOuterRadiusArcsec', 0.0)
+        self._test_misconfig(config, 'deltaAperOuterRadiusArcsec', 1.0)
+
     def _test_misconfig(self, config, field, value):
         """
         Test misconfigured field.


### PR DESCRIPTION
By default, only the per-star and global offsets are computed because of the extra computation time.  These values can also be easily computed in a post-processing step.