### PR TITLE
DM-31880: Add support for new fgcm reference star options.

### DIFF
--- a/python/lsst/fgcmcal/utilities.py
+++ b/python/lsst/fgcmcal/utilities.py
@@ -83,8 +83,20 @@ def makeConfigDict(config, log, camera, maxIter,
     # process the starColorCuts
     starColorCutList = []
     for ccut in config.starColorCuts:
+        if ccut == 'NO_DATA':
+            # No color cuts to apply.
+            break
         parts = ccut.split(',')
         starColorCutList.append([parts[0], parts[1], float(parts[2]), float(parts[3])])
+
+    # process the refStarColorCuts
+    refStarColorCutList = []
+    for ccut in config.refStarColorCuts:
+        if ccut == 'NO_DATA':
+            # No color cuts to apply.
+            break
+        parts = ccut.split(',')
+        refStarColorCutList.append([parts[0], parts[1], float(parts[2]), float(parts[3])])
 
     # TODO: Having direct access to the mirror area from the camera would be
     #  useful.  See DM-16489.
@@ -169,8 +181,10 @@ def makeConfigDict(config, log, camera, maxIter,
                   'refStarSnMin': config.refStarSnMin,
                   'refStarOutlierNSig': config.refStarOutlierNSig,
                   'applyRefStarColorCuts': config.applyRefStarColorCuts,
+                  'useExposureReferenceOffset': config.useExposureReferenceOffset,
                   'illegalValue': FGCM_ILLEGAL_VALUE,  # internally used by fgcm.
                   'starColorCuts': starColorCutList,
+                  'refStarColorCuts': refStarColorCutList,
                   'aperCorrFitNBins': config.aperCorrFitNBins,
                   'aperCorrInputSlopeDict': dict(config.aperCorrInputSlopeDict),
                   'sedBoundaryTermDict': config.sedboundaryterms.toDict()['data'],

--- a/tests/config/fgcmFitCycleHsc.py
+++ b/tests/config/fgcmFitCycleHsc.py
@@ -51,6 +51,8 @@ config.sedterms.data['i'] = fgcmcal.Sedterm(primaryTerm='ri', secondaryTerm=None
                                             extrapolated=False, constant=0.75)
 # Define good stars with an r-i color cut.
 config.starColorCuts = ('r,i,-0.50,2.25',)
+config.refStarColorCuts = ('r, i, 0.0, 2.0',)
+config.useExposureReferenceOffset = True
 config.precomputeSuperStarInitialCycle = False
 config.superStarSubCcdDict = {'g': True,
                               'r': True,

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -92,7 +92,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         nOkZp = 27
         nBadZp = 1093
         nStdStars = 235
-        nPlots = 43
+        nPlots = 48
 
         self._testFgcmFitCycle(instName, testName,
                                0, nZp, nGoodZp, nOkZp, nBadZp, nStdStars, nPlots, skipChecks=True)
@@ -100,17 +100,19 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
                                1, nZp, nGoodZp, nOkZp, nBadZp, nStdStars, nPlots, skipChecks=True)
 
         # We need to create an extra config file to turn on "sub-ccd gray" for testing.
+        # We also want to exercise the code path setting useExposureReferenceOffset = False.
         extraConfigFile = os.path.join(self.testDir, "cycle03_patch_config.py")
         with open(extraConfigFile, "w") as f:
             f.write("config.isFinalCycle = True\n")
             f.write("config.ccdGraySubCcdDict = {'g': True, 'r': True, 'i': True}\n")
+            f.write("config.useExposureReferenceOffset = False")
 
         self._testFgcmFitCycle(instName, testName,
                                2, nZp, nGoodZp, nOkZp, nBadZp, nStdStars, nPlots,
                                extraConfig=extraConfigFile)
 
-        zpOffsets = np.array([-0.0008161436999216676,
-                              0.006149172317236662])
+        zpOffsets = np.array([-0.0008051003096625209,
+                              0.0072303167544305325])
 
         self._testFgcmOutputProducts(instName, testName,
                                      zpOffsets, 36236, 87, 'i', 1)
@@ -135,8 +137,8 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
 
         # These are slightly different from above due to the configuration change
         # mid-way in the separate fits.
-        zpOffsets = np.array([-0.0007102462113834918,
-                              0.005907602142542601])
+        zpOffsets = np.array([-0.0006988655077293515,
+                              0.004102597013115883])
 
         self._testFgcmMultiFit(instName, testName,
                                "physical_filter IN ('HSC-G', 'HSC-R', 'HSC-I')",
@@ -159,8 +161,8 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
                               nBand, i0Std, i0Recon, i10Std, i10Recon)
 
         rawRepeatability = np.array([0.0,
-                                     0.004436014222072738,
-                                     0.00451764656339253])
+                                     0.0025195920941720683,
+                                     0.004095912225403857])
         filterNCalibMap = {'HSC-R': 12,
                            'HSC-I': 15}
 


### PR DESCRIPTION
This PR adds support for the new fgcm 3.9.0 which includes...
1) Reference star color residuals to judge quality of color terms
2) Color cuts to apply specifically to reference stars
3) A per-visit offset based on reference stars that smooths out uniformity variations in surveys (such as HSC SSP) that are not ideally designed for self-calibration.  In particular, this helps with offsets caused by the fgcm model being tripped up by the large changes from HSC-R -> HSC-R2 and HSC-I -> HSC-I2 with limited overlap.

This PR does not change the default configuration or behavior of fgcmcal.