### PR TITLE
DM-12659: Clean up Doxygen tagfile imports

### DIFF
--- a/ups/fgcmcal.cfg
+++ b/ups/fgcmcal.cfg
@@ -8,7 +8,7 @@ import lsst.sconsUtils
 # Otherwise, the rules for which packages to list here are the same as those for
 # table files.
 dependencies = {
-    "required": ["utils", "ndarray"],
+    "required": ["cpputils", "ndarray"],
     "buildRequired": ["boost_test", "pybind11", "ndarray", "pex_exceptions"],
     "optional": [],
     "buildOptional": [],


### PR DESCRIPTION
This PR stops C++ imports of `utils`, fixing a missing tagfile error; `utils` is pure Python, and it's `cpputils` that could potentially produce Doxygen tagfiles.