### PR TITLE
DM-36276: Update test because fgcm is no longer producing an empty plot.

### DIFF
--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -92,7 +92,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         nOkZp = 27
         nBadZp = 1093
         nStdStars = 235
-        nPlots = 48
+        nPlots = 47
 
         self._testFgcmFitCycle(instName, testName,
                                0, nZp, nGoodZp, nOkZp, nBadZp, nStdStars, nPlots, skipChecks=True)


### PR DESCRIPTION
fgcm is being updated to avoid the hexbin bug in matplotlib=3.6.0.  This involves not making an empty log-bin hexbin plot and thus the test for the produced plots needs to be modified.