### PR TITLE
DM-39141: Add doRequirePrimary to star selector when using tables directly.

### DIFF
--- a/python/lsst/fgcmcal/fgcmBuildStarsTable.py
+++ b/python/lsst/fgcmcal/fgcmBuildStarsTable.py
@@ -202,6 +202,8 @@ class FgcmBuildStarsTableConfig(FgcmBuildStarsConfigBase, pipeBase.PipelineTaskC
 
         sourceSelector.unresolved.name = 'extendedness'
 
+        sourceSelector.doRequirePrimary = True
+
 
 class FgcmBuildStarsTableTask(FgcmBuildStarsBaseTask):
     """
@@ -481,6 +483,8 @@ class FgcmBuildStarsTableTask(FgcmBuildStarsBaseTask):
         if self.sourceSelector.config.doIsolated:
             columns.append(self.sourceSelector.config.isolated.parentName)
             columns.append(self.sourceSelector.config.isolated.nChildName)
+        if self.sourceSelector.config.doRequirePrimary:
+            columns.append(self.sourceSelector.config.requirePrimary.primaryColName)
         if self.config.doSubtractLocalBackground:
             columns.append(self.config.localBackgroundFluxField)
 

--- a/python/lsst/fgcmcal/fgcmOutputProducts.py
+++ b/python/lsst/fgcmcal/fgcmOutputProducts.py
@@ -256,6 +256,7 @@ class FgcmOutputProductsConfig(pipeBase.PipelineTaskConfig,
         self.photoCal.match.sourceSelection.flags.good = []
         self.photoCal.match.sourceSelection.flags.bad = ['flag_badStar']
         self.photoCal.match.sourceSelection.doUnresolved = False
+        self.photoCal.match.sourceSelection.doRequirePrimary = False
 
 
 class FgcmOutputProductsTask(pipeBase.PipelineTask):

--- a/tests/config/fgcmBuildStarsTableHsc.py
+++ b/tests/config/fgcmBuildStarsTableHsc.py
@@ -27,6 +27,8 @@ configDir = os.path.join(os.path.dirname(__file__))
 config.physicalFilterMap = HSC_FILTER_DEFINITIONS.physical_to_band
 config.doSubtractLocalBackground = True
 config.sourceSelector["science"].flags.bad.append("localBackground_flag")
+# Our test files do not have detect_isPrimary in the columns.
+config.sourceSelector["science"].doRequirePrimary = False
 config.fgcmLoadReferenceCatalog.load(os.path.join(configDir, 'filterMap.py'))
 config.fgcmLoadReferenceCatalog.applyColorTerms = True
 config.fgcmLoadReferenceCatalog.colorterms.load(os.path.join(configDir, 'colorterms.py'))


### PR DESCRIPTION
Note that the default now uses the isolated star input, which uses detect_isPrimary with https://github.com/lsst/pipe_tasks/pull/789