### PR TITLE
DM-40322: Implement new connections hook for refcat lookups.

### DIFF
--- a/python/lsst/fgcmcal/fgcmBuildFromIsolatedStars.py
+++ b/python/lsst/fgcmcal/fgcmBuildFromIsolatedStars.py
@@ -138,6 +138,9 @@ class FgcmBuildFromIsolatedStarsConnections(pipeBase.PipelineTaskConnections,
             self.prerequisiteInputs.remove("fgcm_lookup_table")
             self.outputs.remove("fgcm_reference_stars")
 
+    def getSpatialBoundsConnections(self):
+        return ("isolated_star_cats", "visit_summaries")
+
 
 class FgcmBuildFromIsolatedStarsConfig(FgcmBuildStarsConfigBase, pipeBase.PipelineTaskConfig,
                                        pipelineConnections=FgcmBuildFromIsolatedStarsConnections):

--- a/python/lsst/fgcmcal/fgcmBuildStarsTable.py
+++ b/python/lsst/fgcmcal/fgcmBuildStarsTable.py
@@ -149,6 +149,9 @@ class FgcmBuildStarsTableConnections(pipeBase.PipelineTaskConnections,
         if not config.doReferenceMatches:
             self.outputs.remove("fgcmReferenceStars")
 
+    def getSpatialBoundsConnections(self):
+        return ("visitSummary",)
+
 
 class FgcmBuildStarsTableConfig(FgcmBuildStarsConfigBase, pipeBase.PipelineTaskConfig,
                                 pipelineConnections=FgcmBuildStarsTableConnections):

--- a/python/lsst/fgcmcal/fgcmCalibrateTractTable.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTractTable.py
@@ -135,6 +135,9 @@ class FgcmCalibrateTractTableConnections(pipeBase.PipelineTaskConnections,
         if not config.fgcmOutputProducts.doZeropointOutput:
             self.prerequisiteInputs.remove("fgcmZeropoints")
 
+    def getSpatialBoundsConnections(self):
+        return ("visitSummary",)
+
 
 class FgcmCalibrateTractTableConfig(FgcmCalibrateTractConfigBase, pipeBase.PipelineTaskConfig,
                                     pipelineConnections=FgcmCalibrateTractTableConnections):

--- a/python/lsst/fgcmcal/fgcmOutputProducts.py
+++ b/python/lsst/fgcmcal/fgcmOutputProducts.py
@@ -163,6 +163,9 @@ class FgcmOutputProductsConnections(pipeBase.PipelineTaskConnections,
         if not config.doReferenceCalibration:
             self.outputs.remove("fgcmOffsets")
 
+    def getSpatialBoundsConnections(self):
+        return ("fgcmPhotoCalib",)
+
 
 class FgcmOutputProductsConfig(pipeBase.PipelineTaskConfig,
                                pipelineConnections=FgcmOutputProductsConnections):


### PR DESCRIPTION
This is part of a new, slightly-better fix for DM-40243.