### PR TITLE
DM-42285: Update for use with future numpy (1.25+) and tighten down loose ends.

### DIFF
--- a/python/lsst/fgcmcal/fgcmBuildFromIsolatedStars.py
+++ b/python/lsst/fgcmcal/fgcmBuildFromIsolatedStars.py
@@ -35,7 +35,7 @@ import hpgeom as hpg
 from smatch.matcher import Matcher
 from astropy.table import Table, vstack
 
-from fgcm.fgcmUtilities import objFlagDict
+from fgcm.fgcmUtilities import objFlagDict, histogram_rev_sorted
 
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
@@ -633,8 +633,9 @@ class FgcmBuildFromIsolatedStarsTask(FgcmBuildStarsBaseTask):
         ipnest = hpg.angle_to_pixel(self.config.densityCutNside, fgcm_obj["ra"], fgcm_obj["dec"])
         # Use the esutil.stat.histogram function to pull out the histogram of
         # grouped pixels, and the rev_indices which describes which inputs
-        # are grouped together.
-        hist, rev_indices = esutil.stat.histogram(ipnest, rev=True)
+        # are grouped together.  The fgcm histogram_rev_sorted shim
+        # ensures that the indices are properly sorted.
+        hist, rev_indices = histogram_rev_sorted(ipnest)
 
         obj_use = np.ones(len(fgcm_obj), dtype=bool)
 
@@ -717,7 +718,7 @@ class FgcmBuildFromIsolatedStarsTask(FgcmBuildStarsBaseTask):
 
         # Split into healpix pixels for more efficient matching.
         ipnest = hpg.angle_to_pixel(self.config.coarseNside, fgcm_obj["ra"], fgcm_obj["dec"])
-        hpix, revpix = esutil.stat.histogram(ipnest, rev=True)
+        hpix, revpix = histogram_rev_sorted(ipnest)
 
         pixel_cats = []
 
@@ -810,7 +811,7 @@ class FgcmBuildFromIsolatedStarsTask(FgcmBuildStarsBaseTask):
         a, b = esutil.numpy_util.match(visit_cat["visit"], star_obs["visit"][ok])
         visit_index[b] = a
 
-        h, rev = esutil.stat.histogram(visit_index, rev=True)
+        h, rev = histogram_rev_sorted(visit_index)
 
         visit_cat["deltaAper"] = -9999.0
         h_use, = np.where(h >= 3)

--- a/python/lsst/fgcmcal/fgcmCalibrateTractBase.py
+++ b/python/lsst/fgcmcal/fgcmCalibrateTractBase.py
@@ -321,9 +321,9 @@ class FgcmCalibrateTractBaseTask(pipeBase.PipelineTask, abc.ABC):
                 self.log.info("  Band %s, repeatability: %.2f mmag" % (band, rep))
 
             # Check for convergence
-            if np.alltrue((previousReservedRawRepeatability
-                           - fgcmFitCycle.fgcmPars.compReservedRawRepeatability)
-                          < self.config.convergenceTolerance):
+            if np.all((previousReservedRawRepeatability
+                       - fgcmFitCycle.fgcmPars.compReservedRawRepeatability)
+                      < self.config.convergenceTolerance):
                 self.log.info("Raw repeatability has converged after cycle number %d." % (cycleNumber))
                 converged = True
             else:

--- a/python/lsst/fgcmcal/fgcmFitCycle.py
+++ b/python/lsst/fgcmcal/fgcmFitCycle.py
@@ -1785,7 +1785,7 @@ class FgcmFitCycleTask(pipeBase.PipelineTask):
         rec = parCat.addNew()
 
         # info section
-        rec['nCcd'] = parInfo['NCCD']
+        rec['nCcd'] = parInfo['NCCD'][0]
         rec['lutFilterNames'] = lutFilterNameString
         rec['fitBands'] = fitBandString
         # note these are not currently supported here.
@@ -1814,7 +1814,7 @@ class FgcmFitCycleTask(pipeBase.PipelineTask):
                     'compEpsilonCcdMap', 'compEpsilonCcdNStarMap', 'compExpRefOffset']
 
         for scalarName in scalarNames:
-            rec[scalarName] = pars[scalarName.upper()]
+            rec[scalarName] = pars[scalarName.upper()][0]
 
         for arrName in arrNames:
             rec[arrName][:] = np.atleast_1d(pars[0][arrName.upper()])[:]

--- a/python/lsst/fgcmcal/fgcmOutputProducts.py
+++ b/python/lsst/fgcmcal/fgcmOutputProducts.py
@@ -35,7 +35,6 @@ import copy
 
 import numpy as np
 import hpgeom as hpg
-import esutil
 from astropy import units
 
 import lsst.daf.base as dafBase
@@ -561,7 +560,7 @@ class FgcmOutputProductsTask(pipeBase.PipelineTask):
             stdCat['coord_dec'],
             degrees=False,
         )
-        h, rev = esutil.stat.histogram(ipring, rev=True)
+        h, rev = fgcm.fgcmUtilities.histogram_rev_sorted(ipring)
 
         gdpix, = np.where(h >= self.config.referencePixelizationMinStars)
 

--- a/tests/fgcmcalTestBase.py
+++ b/tests/fgcmcalTestBase.py
@@ -566,7 +566,7 @@ class FgcmcalTestBase(object):
                 photoCalMeanCalMags[i] = testCal.instFluxToMagnitude(rec['slot_CalibFlux_instFlux'])
                 photoCalMags[i] = testCal.instFluxToMagnitude(rec['slot_CalibFlux_instFlux'],
                                                               rec.getCentroid())
-                zptMeanCalMags[i] = fgcmZpt - 2.5*np.log10(rec['slot_CalibFlux_instFlux'])
+                zptMeanCalMags[i] = fgcmZpt[0] - 2.5*np.log10(rec['slot_CalibFlux_instFlux'])
 
             # These should be very close but some tiny differences because the fgcm value
             # is defined at the center of the bbox, and the photoCal is the mean over the box

--- a/tests/test_fgcmcal_hsc.py
+++ b/tests/test_fgcmcal_hsc.py
@@ -102,7 +102,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
         nGoodZp = 27
         nOkZp = 27
         nBadZp = 1093
-        nStdStars = 235
+        nStdStars = 237
         nPlots = 47
 
         # We need an extra config file to turn off parquet format.
@@ -239,7 +239,7 @@ class FgcmcalTestHSC(fgcmcalTestBase.FgcmcalTestBase, lsst.utils.tests.TestCase)
                               nBand, i0Std, i0Recon, i10Std, i10Recon)
 
         rawRepeatability = np.array([0.0,
-                                     0.005631336514834158,
+                                     0.003440500079097844,
                                      0.004095912225403857])
         filterNCalibMap = {'HSC-R': 12,
                            'HSC-I': 15}


### PR DESCRIPTION
This uses the new version of fgcm (PR https://github.com/lsst/fgcm/pull/39).  

This takes advantage of various optimizations and also a fix to https://github.com/esheldon/esutil/issues/87

Apparently this has been "loose" forever but it just happened to work okay until now.

Using this branch and numpy 1.24 the fgcmcal tests are 5% faster (and this is a lower limit on the speed improvement in larger dataset). Using this branch and numpy 1.26 the fgcmcal tests are another 5% faster still.