### PR TITLE
DM-40441: Drop unnecessary argument to SimplePipelineExecutor.from_pipeline.

### DIFF
--- a/tests/fgcmcalTestBase.py
+++ b/tests/fgcmcalTestBase.py
@@ -131,7 +131,6 @@ class FgcmcalTestBase(object):
 
         executor = SimplePipelineExecutor.from_pipeline(pipeline,
                                                         where=queryString,
-                                                        root=repo,
                                                         butler=butler,
                                                         resources=resources)
         quanta = executor.run(register_dataset_types=registerDatasetTypes)


### PR DESCRIPTION
The 'root' argument never existed, but until DM-40441 this method seems to have accidentally accepted (and ignored) arbitrary kwargs.